### PR TITLE
Add full backup and restore scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,11 @@
         "start:i18n": "docker compose -f ./yaml/i18n.yaml --env-file ./env/i18n.env up",
         "start:i18n:d": "docker compose -f ./yaml/i18n.yaml --env-file ./env/i18n.env up -d",
         "start:mq": "docker compose -f ./yaml/mq.yaml --env-file ./env/mq.env up",
-        "start:mq:d": "docker compose -f ./yaml/mq.yaml --env-file ./env/mq.env up -d"
+        "start:mq:d": "docker compose -f ./yaml/mq.yaml --env-file ./env/mq.env up -d",
+        "backup:db": "node scripts/backup_d7_postgres.js",
+        "backup:db:full": "node scripts/backup_d7_postgres.js --full",
+        "backup:full": "node scripts/backup_full.js",
+        "restore:full": "node scripts/restore_full.js"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.735.0",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,66 @@
+# Backup & Restore Scripts
+
+Scripts for backing up and restoring the Directus (d7) instance, including database, uploads, and extensions.
+
+## Prerequisites
+
+- Docker containers `d7_postgres` and `d7_directus` must be running (for backup) or `d7_postgres` must be running (for restore)
+- Node.js dependencies installed (`yarn install` from project root)
+- AWS credentials configured for S3 uploads (optional — backups are kept locally if S3 fails)
+
+## Scripts
+
+### `backup_full.js` — Full Backup
+
+Creates a single `.tar.gz` archive containing:
+- **Database**: `pg_dump` of the full PostgreSQL database (custom format)
+- **Uploads**: All files from `/directus/uploads`
+- **Extensions**: All extensions (with `node_modules` stripped)
+
+Uploads the archive to S3 at `s3://frg-directus-backups/full-backups/`. If S3 upload fails, the archive is kept locally at `/tmp/`.
+
+```bash
+yarn backup:full
+```
+
+### `backup_d7_postgres.js` — Database-Only Backup
+
+Dumps the PostgreSQL database as a gzipped SQL file and uploads to S3.
+
+```bash
+yarn backup:db          # excludes directus_revisions table
+yarn backup:db:full     # includes all tables
+```
+
+### `restore_full.js` — Full Restore
+
+Restores from a `.tar.gz` archive created by `backup_full.js`. This will:
+1. Stop the Directus container
+2. Drop and recreate the database
+3. Restore the database from the dump
+4. Replace uploads and extensions on the host (volume-mounted)
+5. Restart Directus
+
+```bash
+yarn restore:full <path-to-backup.tar.gz>
+```
+
+## Environment Variables
+
+Set in `env/d7.env`:
+
+| Variable | Description |
+|---|---|
+| `D7_POSTGRES_DB` | PostgreSQL database name |
+| `D7_POSTGRES_USER` | PostgreSQL user |
+| `BACKUP_BUCKET_NAME` | S3 bucket for storing backups |
+| `BACKUP_REGION` | AWS region for the S3 bucket |
+
+## Archive Structure
+
+```
+backup.tar.gz
+  database.dump     # pg_restore compatible (custom format)
+  uploads/          # Directus uploaded files
+  extensions/       # Directus extensions (no node_modules)
+```

--- a/scripts/backup_full.js
+++ b/scripts/backup_full.js
@@ -1,0 +1,155 @@
+const { exec, execSync } = require('child_process');
+const path = require('path');
+const dotenv = require('dotenv');
+const fs = require('fs');
+const { S3Client } = require('@aws-sdk/client-s3');
+const { Upload } = require('@aws-sdk/lib-storage');
+
+// Load environment variables
+dotenv.config({ path: path.join(__dirname, '../env/d7.env') });
+
+// Validate required environment variables
+const requiredVars = ['D7_POSTGRES_DB', 'D7_POSTGRES_USER', 'BACKUP_REGION', 'BACKUP_BUCKET_NAME'];
+for (const varName of requiredVars) {
+    if (!process.env[varName]) {
+        console.error(`Error: ${varName} environment variable is required`);
+        process.exit(1);
+    }
+}
+
+const {
+    D7_POSTGRES_DB: dbName,
+    D7_POSTGRES_USER: dbUser,
+    BACKUP_REGION: awsRegion,
+    BACKUP_BUCKET_NAME: bucketName
+} = process.env;
+
+const dateString = new Date().toISOString().replace(/[:.]/g, '-');
+const tmpDir = `/tmp/directus-backup-${dateString}`;
+const archiveName = `${dateString}-full-backup.tar.gz`;
+const archivePath = `/tmp/${archiveName}`;
+
+console.log(`Starting full backup at ${dateString}...`);
+
+// Initialize S3 client
+const s3Client = new S3Client({ region: awsRegion });
+
+function execPromise(command, options = {}) {
+    return new Promise((resolve, reject) => {
+        exec(command, { maxBuffer: 1024 * 1024 * 100, ...options }, (err, stdout, stderr) => {
+            if (err) {
+                console.error(`stderr: ${stderr}`);
+                reject(err);
+                return;
+            }
+            resolve(stdout.trim());
+        });
+    });
+}
+
+async function uploadToS3(filePath) {
+    const fileStream = fs.createReadStream(filePath);
+
+    try {
+        console.log(`Uploading ${filePath} to S3...`);
+
+        const upload = new Upload({
+            client: s3Client,
+            params: {
+                Bucket: bucketName,
+                Key: `full-backups/${path.basename(filePath)}`,
+                Body: fileStream,
+                ContentType: 'application/gzip'
+            },
+            queueSize: 4,
+            partSize: 1024 * 1024 * 5
+        });
+
+        upload.on('httpUploadProgress', (progress) => {
+            if (progress.total) {
+                console.log(`Upload progress: ${Math.round((progress.loaded / progress.total) * 100)}%`);
+            }
+        });
+
+        await upload.done();
+        console.log(`\u2713 Successfully uploaded to s3://${bucketName}/full-backups/${path.basename(filePath)}`);
+        return true;
+    } catch (err) {
+        console.error('S3 upload error:', err);
+        return false;
+    }
+}
+
+async function createFullBackup() {
+    // Create temp directory
+    fs.mkdirSync(tmpDir, { recursive: true });
+
+    // 1. Database dump
+    console.log('1/3 Dumping database...');
+    const dumpFile = path.join(tmpDir, 'database.dump');
+    const dumpCommand = `docker exec d7_postgres pg_dump -U ${dbUser} -d ${dbName} -F c -f /tmp/backup.dump && docker cp d7_postgres:/tmp/backup.dump ${dumpFile}`;
+    await execPromise(dumpCommand);
+    const dbSize = (fs.statSync(dumpFile).size / 1024 / 1024).toFixed(2);
+    console.log(`\u2713 Database dump: ${dbSize} MB`);
+
+    // 2. Uploads
+    console.log('2/3 Copying uploads...');
+    await execPromise(`docker cp d7_directus:/directus/uploads ${path.join(tmpDir, 'uploads')}`);
+    console.log('\u2713 Uploads copied');
+
+    // 3. Extensions (exclude node_modules)
+    console.log('3/3 Copying extensions...');
+    const extTmp = path.join(tmpDir, 'extensions');
+    await execPromise(`docker cp d7_directus:/directus/extensions ${extTmp}`);
+    // Remove node_modules from extensions to save space
+    const extDirs = fs.readdirSync(extTmp);
+    for (const dir of extDirs) {
+        const nmPath = path.join(extTmp, dir, 'node_modules');
+        if (fs.existsSync(nmPath)) {
+            fs.rmSync(nmPath, { recursive: true, force: true });
+            console.log(`  Stripped node_modules from ${dir}`);
+        }
+    }
+    console.log('\u2713 Extensions copied (without node_modules)');
+
+    // Create single tar.gz archive
+    console.log('Creating archive...');
+    await execPromise(`tar czf ${archivePath} -C ${tmpDir} .`);
+    const archiveSize = (fs.statSync(archivePath).size / 1024 / 1024).toFixed(2);
+    console.log(`\u2713 Archive created: ${archiveName} (${archiveSize} MB)`);
+
+    // Upload to S3
+    const uploadSuccess = await uploadToS3(archivePath);
+    if (!uploadSuccess) {
+        console.warn(`\u26a0 S3 upload failed. Archive kept at: ${archivePath}`);
+    }
+
+    // Cleanup temp dir (but keep archive if S3 failed)
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    await execPromise('docker exec d7_postgres rm -f /tmp/backup.dump');
+    if (uploadSuccess) {
+        fs.unlinkSync(archivePath);
+        console.log('Cleaned up temp files');
+        console.log(`\n\u2713 Full backup complete: s3://${bucketName}/full-backups/${archiveName}`);
+    } else {
+        console.log(`\n\u2713 Local backup complete: ${archivePath}`);
+    }
+}
+
+createFullBackup()
+    .then(() => process.exit(0))
+    .catch((err) => {
+        console.error('Backup failed:', err);
+        if (fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true, force: true });
+        process.exit(1);
+    });
+
+process.on('SIGTERM', () => {
+    console.log('Received SIGTERM, terminating...');
+    process.exit(1);
+});
+
+process.on('SIGINT', () => {
+    console.log('Received SIGINT, terminating...');
+    process.exit(1);
+});

--- a/scripts/restore_full.js
+++ b/scripts/restore_full.js
@@ -1,0 +1,94 @@
+const { exec } = require('child_process');
+const path = require('path');
+const dotenv = require('dotenv');
+const fs = require('fs');
+
+// Load environment variables
+dotenv.config({ path: path.join(__dirname, '../env/d7.env') });
+
+const {
+    D7_POSTGRES_DB: dbName,
+    D7_POSTGRES_USER: dbUser
+} = process.env;
+
+const archivePath = process.argv[2];
+if (!archivePath) {
+    console.error('Usage: node scripts/restore_full.js <path-to-backup.tar.gz>');
+    process.exit(1);
+}
+
+if (!fs.existsSync(archivePath)) {
+    console.error(`File not found: ${archivePath}`);
+    process.exit(1);
+}
+
+const tmpDir = `/tmp/directus-restore-${Date.now()}`;
+
+function execPromise(command, options = {}) {
+    return new Promise((resolve, reject) => {
+        console.log(`> ${command}`);
+        exec(command, { maxBuffer: 1024 * 1024 * 100, ...options }, (err, stdout, stderr) => {
+            if (stderr) console.error(stderr);
+            if (err) {
+                reject(err);
+                return;
+            }
+            resolve(stdout.trim());
+        });
+    });
+}
+
+async function restore() {
+    // Extract archive
+    console.log('1/5 Extracting archive...');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    await execPromise(`tar xzf ${path.resolve(archivePath)} -C ${tmpDir}`);
+    console.log('\u2713 Extracted');
+
+    // Stop Directus
+    console.log('2/5 Stopping Directus...');
+    await execPromise('docker stop d7_directus');
+    console.log('\u2713 Directus stopped');
+
+    // Restore database
+    console.log('3/5 Restoring database...');
+    await execPromise(`docker exec d7_postgres psql -U ${dbUser} -d postgres -c "DROP DATABASE IF EXISTS ${dbName};"`);
+    await execPromise(`docker exec d7_postgres psql -U ${dbUser} -d postgres -c "CREATE DATABASE ${dbName};"`);
+    await execPromise(`docker cp ${path.join(tmpDir, 'database.dump')} d7_postgres:/tmp/restore.dump`);
+    await execPromise(`docker exec d7_postgres pg_restore -U ${dbUser} -d ${dbName} --no-owner /tmp/restore.dump`);
+    await execPromise('docker exec d7_postgres rm -f /tmp/restore.dump');
+    console.log('\u2713 Database restored');
+
+    // Restore uploads (volume-mounted from host)
+    console.log('4/5 Restoring uploads...');
+    const uploadsDir = path.join(__dirname, '../d7/directus/uploads');
+    fs.rmSync(uploadsDir, { recursive: true, force: true });
+    await execPromise(`cp -r ${path.join(tmpDir, 'uploads')} ${uploadsDir}`);
+    console.log('\u2713 Uploads restored');
+
+    // Restore extensions (volume-mounted from host)
+    console.log('5/5 Restoring extensions...');
+    const extensionsDir = path.join(__dirname, '../d7/directus/extensions');
+    fs.rmSync(extensionsDir, { recursive: true, force: true });
+    await execPromise(`cp -r ${path.join(tmpDir, 'extensions')} ${extensionsDir}`);
+    console.log('\u2713 Extensions restored');
+
+    // Start Directus
+    console.log('Starting Directus...');
+    await execPromise('docker start d7_directus');
+    console.log('\u2713 Directus started');
+
+    // Cleanup
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    console.log('\u2713 Cleaned up temp files');
+
+    console.log('\n\u2713 Full restore complete!');
+}
+
+restore()
+    .then(() => process.exit(0))
+    .catch((err) => {
+        console.error('Restore failed:', err);
+        if (fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true, force: true });
+        process.exit(1);
+    });


### PR DESCRIPTION
## Summary
- Adds `backup_full.js` — creates a single `.tar.gz` archive of the database, uploads, and extensions, then uploads to S3
- Adds `restore_full.js` — restores from that archive with a single command (`yarn restore:full <path>`)
- Adds `scripts/README.md` documenting usage, env vars, and archive structure
- Adds `backup:db`, `backup:db:full`, `backup:full`, and `restore:full` npm scripts to `package.json`

## Test plan
- [x] Ran `yarn backup:full` — archive created successfully (S3 upload fails locally due to credentials, works on server)
- [x] Ran `yarn restore:full <archive>` — database, uploads, and extensions restored correctly
- [x] Verified 3 users, 1 upload file, and 6 extensions present after restore
- [x] Directus started and served requests after restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)