### PR TITLE
Add food pantries translation script

### DIFF
--- a/env/d7.env.template
+++ b/env/d7.env.template
@@ -30,3 +30,8 @@ AUTH_KEYCLOAK_ISSUER_URL=http://localhost:8123/realms/master/.well-known/openid-
 
 BACKUP_BUCKET_NAME=frg-directus-backups
 BACKUP_REGION=us-east-2
+
+LIBRETRANSLATE_URL=http://localhost:5000
+LIBRETRANSLATE_API_KEY=
+
+D7_DIRECTUS_STATIC_TOKEN=

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
         "backup:db": "node scripts/backup_d7_postgres.js",
         "backup:db:full": "node scripts/backup_d7_postgres.js --full",
         "backup:full": "node scripts/backup_full.js",
-        "restore:full": "node scripts/restore_full.js"
+        "restore:full": "node scripts/restore_full.js",
+        "translate:foodPantries": "node scripts/translate_food_pantries.js"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.735.0",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -45,6 +45,25 @@ Restores from a `.tar.gz` archive created by `backup_full.js`. This will:
 yarn restore:full <path-to-backup.tar.gz>
 ```
 
+### `translate_food_pantries.js` — Translate Food Pantries
+
+Translates the `name`, `notes`, and `hours` fields for all food pantries into the languages defined in the `languages` collection.
+
+- **name**: Translated as plain text
+- **notes**: Markdown is converted to HTML, translated (preserving tags), then converted back to markdown
+- **hours**: JSON structure is preserved (`days`, `timeStart`, `timeEnd` unchanged), only the optional `notes` field within each entry is translated
+
+The script is idempotent — it skips translations that are already up to date. A translation is considered stale when the food pantry's `lastVerified` timestamp is newer than the translation's `lastUpdated` timestamp.
+
+```bash
+yarn translate:foodPantries
+```
+
+Requires:
+- Directus running locally with a static token configured
+- LibreTranslate running (default: `http://localhost:5000`)
+- Languages populated in the `languages` collection
+
 ## Environment Variables
 
 Set in `env/d7.env`:
@@ -55,6 +74,9 @@ Set in `env/d7.env`:
 | `D7_POSTGRES_USER` | PostgreSQL user |
 | `BACKUP_BUCKET_NAME` | S3 bucket for storing backups |
 | `BACKUP_REGION` | AWS region for the S3 bucket |
+| `D7_DIRECTUS_STATIC_TOKEN` | Static API token for Directus admin user |
+| `LIBRETRANSLATE_URL` | LibreTranslate endpoint (default: `http://localhost:5000`) |
+| `LIBRETRANSLATE_API_KEY` | LibreTranslate API key (optional, if auth is required) |
 
 ## Archive Structure
 

--- a/scripts/translate_food_pantries.js
+++ b/scripts/translate_food_pantries.js
@@ -1,0 +1,187 @@
+const http = require('http');
+const path = require('path');
+const dotenv = require('dotenv');
+const showdown = require('showdown');
+const TurndownService = require('turndown');
+
+dotenv.config({ path: path.join(__dirname, '../env/d7.env') });
+
+const DIRECTUS_URL = 'http://localhost:8055';
+const LIBRETRANSLATE_URL = process.env.LIBRETRANSLATE_URL || 'http://localhost:5000';
+const LIBRETRANSLATE_API_KEY = process.env.LIBRETRANSLATE_API_KEY || '';
+const BATCH_SIZE = 50;
+
+const mdToHtml = new showdown.Converter();
+const htmlToMd = new TurndownService({ bulletListMarker: '-' });
+
+function fetch(url, opts = {}) {
+    return new Promise((resolve, reject) => {
+        const req = http.request(url, {
+            method: opts.method || 'GET',
+            headers: opts.headers || {}
+        }, res => {
+            let data = '';
+            res.on('data', c => data += c);
+            res.on('end', () => {
+                try {
+                    resolve(JSON.parse(data));
+                } catch (e) {
+                    reject(new Error(`Failed to parse response from ${url}: ${data.slice(0, 200)}`));
+                }
+            });
+        });
+        req.on('error', reject);
+        if (opts.body) req.write(opts.body);
+        req.end();
+    });
+}
+
+const STATIC_TOKEN = process.env.D7_DIRECTUS_STATIC_TOKEN;
+if (!STATIC_TOKEN) {
+    console.error('Error: D7_DIRECTUS_STATIC_TOKEN is required in d7.env');
+    process.exit(1);
+}
+
+async function translate(text, targetLang) {
+    const body = { q: text, source: 'en', target: targetLang };
+    if (LIBRETRANSLATE_API_KEY) body.api_key = LIBRETRANSLATE_API_KEY;
+    const result = await fetch(`${LIBRETRANSLATE_URL}/translate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+    });
+    return result.translatedText;
+}
+
+async function translateMarkdown(md, targetLang) {
+    const html = mdToHtml.makeHtml(md);
+    const body = { q: html, source: 'en', target: targetLang, format: 'html' };
+    if (LIBRETRANSLATE_API_KEY) body.api_key = LIBRETRANSLATE_API_KEY;
+    const result = await fetch(`${LIBRETRANSLATE_URL}/translate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+    });
+    return htmlToMd.turndown(result.translatedText);
+}
+
+async function translateHours(hours, targetLang) {
+    if (!hours) return null;
+    const translated = [];
+    for (const entry of hours) {
+        const copy = { days: entry.days, timeStart: entry.timeStart, timeEnd: entry.timeEnd };
+        if (entry.notes) {
+            copy.notes = await translate(entry.notes, targetLang);
+        }
+        translated.push(copy);
+    }
+    return translated;
+}
+
+async function getLanguages(headers) {
+    const result = await fetch(`${DIRECTUS_URL}/items/languages?fields=code`, { headers });
+    return result.data.map(l => l.code);
+}
+
+async function main() {
+    console.log('Starting food pantries translation...\n');
+
+    const headers = { 'Authorization': `Bearer ${STATIC_TOKEN}`, 'Content-Type': 'application/json' };
+
+    // Get target languages
+    const langs = await getLanguages(headers);
+    console.log(`Target languages: ${langs.join(', ')}`);
+
+    // Count total pantries
+    const countResult = await fetch(`${DIRECTUS_URL}/items/foodPantries?aggregate[count]=id`, { headers });
+    const total = countResult.data[0].count.id;
+    console.log(`Total food pantries: ${total}\n`);
+
+    let offset = 0;
+    let processed = 0;
+    let translated = 0;
+    let skipped = 0;
+    let errors = 0;
+
+    while (offset < total) {
+
+        const batch = await fetch(
+            `${DIRECTUS_URL}/items/foodPantries?fields=id,name,notes,hours,lastVerified,translations.id,translations.languages_code,translations.lastUpdated&limit=${BATCH_SIZE}&offset=${offset}&sort=id`,
+            { headers }
+        );
+
+        if (!batch.data || batch.data.length === 0) break;
+
+        for (const pantry of batch.data) {
+            processed++;
+
+            try {
+                for (const lang of langs) {
+                    const existing = (pantry.translations || []).find(t => t.languages_code === lang);
+
+                    if (existing) {
+                        // Skip if translation exists and is newer than lastVerified
+                        const lastVerified = pantry.lastVerified ? new Date(pantry.lastVerified) : null;
+                        const lastUpdated = existing.lastUpdated ? new Date(existing.lastUpdated) : null;
+
+                        if (lastUpdated && (!lastVerified || lastVerified <= lastUpdated)) {
+                            skipped++;
+                            continue;
+                        }
+                        // Otherwise, re-translate (source data changed since last translation)
+                    }
+
+            
+                    // Translate fields
+                    const translatedName = pantry.name ? await translate(pantry.name, lang) : null;
+                    const translatedNotes = pantry.notes ? await translateMarkdown(pantry.notes, lang) : null;
+                    const translatedHours = await translateHours(pantry.hours, lang);
+
+                    const payload = {
+                        languages_code: lang,
+                        name: translatedName,
+                        notes: translatedNotes,
+                        hours: translatedHours
+                    };
+
+                    if (existing) {
+                        // Update existing translation
+                        payload.id = existing.id;
+                        await fetch(`${DIRECTUS_URL}/items/foodPantries/${pantry.id}`, {
+                            method: 'PATCH',
+                            headers,
+                            body: JSON.stringify({ translations: { update: [payload] } })
+                        });
+                    } else {
+                        // Create new translation
+                        await fetch(`${DIRECTUS_URL}/items/foodPantries/${pantry.id}`, {
+                            method: 'PATCH',
+                            headers,
+                            body: JSON.stringify({ translations: { create: [payload] } })
+                        });
+                    }
+
+                    translated++;
+                }
+
+                if (processed % 10 === 0 || processed === parseInt(total)) {
+                    console.log(`[${processed}/${total}] translated: ${translated}, skipped: ${skipped}, errors: ${errors}`);
+                }
+            } catch (err) {
+                errors++;
+                console.error(`  Error on "${pantry.name}" (${pantry.id}): ${err.message}`);
+            }
+        }
+
+        offset += BATCH_SIZE;
+    }
+
+    console.log(`\nDone! Processed: ${processed}, Translated: ${translated}, Skipped: ${skipped}, Errors: ${errors}`);
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch(err => {
+        console.error('Fatal error:', err);
+        process.exit(1);
+    });


### PR DESCRIPTION
## Summary
- Adds `translate_food_pantries.js` script that translates `name`, `notes`, and `hours` fields via LibreTranslate
- Markdown in `notes` is preserved by converting to HTML for translation, then back to markdown
- `hours` JSON structure is preserved — only the optional `notes` text within entries is translated
- Idempotent: skips translations where `lastUpdated` >= `lastVerified`
- Uses static Directus token and configurable LibreTranslate URL/API key from `d7.env`
- Updates `scripts/README.md` with translation docs and new env vars
- Adds `translate:foodPantries` npm script

## Test plan
- [x] Tested translation of 5 food pantries across Spanish, Korean, Indonesian
- [x] Verified markdown links and formatting preserved in notes
- [x] Verified hours JSON structure preserved with only notes translated
- [x] Verified skip logic for up-to-date translations
- [ ] Full run across all 1,393 food pantries

🤖 Generated with [Claude Code](https://claude.com/claude-code)