### PR TITLE
Update documentation with consistent voice

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,62 +1,76 @@
-- run `yarn start:auth`
-- admin dashboard looks like:  http://localhost:8123
-- frontend dashboard looks like: http://localhost:8123/realms/master/account/#/
+# Authentication (Keycloak)
 
-# Keycloak Setup for Ideal Workflow
-This is a guide to set up Keycloak for an ideal workflow, which includes regular user accounts that can only be created by an admin, no automatic account creation, social login buttons for users, and users only able to login with their email addresses. Here are the steps to can follow:
+## Running
 
-## Step 1: Install Keycloak
+```bash
+yarn start:auth
+```
 
-First, you need to install Keycloak. Follow the instructions provided in the Getting Started guide for Docker at https://www.keycloak.org/getting-started/getting-started-docker.
+| Dashboard | URL |
+|---|---|
+| Admin | http://localhost:8123 |
+| User account | http://localhost:8123/realms/master/account/#/ |
 
-## Step 2: Enabling Google IDP
-Note. For Google or Microsoft IDP, do not use the default idp social login. 
+## Keycloak Setup
 
-Instead, create a new idp and configure the following: 
-- AUTH_URL
-- TOKEN_URL
-- PROFILE_URL as User Info URL 
+This configuration provides: admin-created user accounts only (no self-registration), social login via Google, and email-based authentication.
 
-[Link to github issue with OIDC solution](https://github.com/keycloak/keycloak/issues/14258)
+### 1. Install Keycloak
 
-## Step 3: Disable Automatic User Creation
+Follow the [Getting Started with Docker](https://www.keycloak.org/getting-started/getting-started-docker) guide.
 
-By default, Keycloak automatically creates a user account for any user who successfully logs in via a social login provider. To disable this automatic user creation, follow the instructions provided in the Keycloak documentation at https://www.keycloak.org/docs/9.0/server_admin/index.html#disabling-automatic-user-creation.
+### 2. Enable Google IDP
 
-Specifically, follow the instructions in the "Disabling Automatic User Creation" section to disable automatic user creation.
+Do not use the default social login IDP for Google or Microsoft. Instead, create a new IDP and configure:
 
-## Step 4: Configure Default Identity Provider
+- `AUTH_URL`
+- `TOKEN_URL`
+- `PROFILE_URL` as User Info URL
 
-To ensure that users are only presented with social login buttons and are not prompted to enter a username and password, you need to configure the default identity provider to be Google. Follow the instructions provided in the Keycloak documentation at https://www.keycloak.org/docs/latest/server_admin/index.html#default_identity_provider.
+See [this GitHub issue](https://github.com/keycloak/keycloak/issues/14258) for the OIDC solution.
 
-Specifically, follow the instructions in the "Configuring the Default Identity Provider" section to configure Google as the default identity provider.
+Create a Google app with redirect URI:
 
-## Step 5: Create Admin and Regular User Accounts
+```
+http://localhost:8080/realms/master/broker/google/endpoint
+```
 
-Now that you have configured Keycloak for social login, you need to create admin and regular user accounts. Follow the instructions provided in the Keycloak documentation at https://www.keycloak.org/docs/latest/server_admin/index.html#creating-users.
+### 3. Disable automatic user creation
 
-Specifically, follow the instructions in the "Creating Users" section to create both an admin user account and a regular user account.
+By default, Keycloak creates accounts for any user who logs in via a social provider. To disable this:
 
+1. Go to **Authentication** in the menu.
+2. Select **First Broker Login** from the list.
+3. Set **Create User If Unique** to `DISABLED`.
+4. Set **Confirm Link Existing Account** to `DISABLED`.
 
-## Step 6: Configure the login page
+Reference: [Keycloak docs — Disabling Automatic User Creation](https://www.keycloak.org/docs/9.0/server_admin/index.html#disabling-automatic-user-creation)
 
-In the Authentication tab, click on the Flows tab and select the Browser flow. Click on the Copy button to make a copy of the flow. Then, click on the new copy of the flow and configure it as follows:
+### 4. Configure default identity provider
 
-- Delete the Username Password Form form.
-- Add an Identity Provider Redirector form after the Browser form.
-- Move the Identity Provider Redirector form to the top of the list.
-- In the Identity Provider Redirector form settings, select the desired identity provider (e.g. Google).
+Set Google as the default IDP so users see social login buttons instead of a username/password form.
 
----
+Reference: [Keycloak docs — Default Identity Provider](https://www.keycloak.org/docs/latest/server_admin/index.html#default_identity_provider)
 
-1. create Google app
-  1. redirect uri looks like http://localhost:8080/realms/master/broker/google/endpoint
-2. add Google IDP
-3. To disable user creation:
-  1. Click Authentication in the menu.
-  2. Select First Broker Login from the list.
-  3. Set Create User If Unique to DISABLED.
-  4. Set Confirm Link Existing Account to DISABLED.
-4. admin login looks like http://localhost:8080/admin/
-5. frontend login looks like http://localhost:8080/realms/master/account/#/
-6. well known looks like http://localhost:8080/realms/master/.well-known/openid-configuration
+### 5. Create user accounts
+
+Create admin and regular user accounts via the Keycloak admin console.
+
+Reference: [Keycloak docs — Creating Users](https://www.keycloak.org/docs/latest/server_admin/index.html#creating-users)
+
+### 6. Configure the login page
+
+1. Go to **Authentication > Flows** and select the **Browser** flow.
+2. Click **Copy** to duplicate the flow.
+3. In the copy, delete the **Username Password Form**.
+4. Add an **Identity Provider Redirector** after the Browser form.
+5. Move it to the top of the list.
+6. In its settings, select the desired identity provider (e.g., Google).
+
+## Reference URLs
+
+| Resource | URL |
+|---|---|
+| Admin dashboard | http://localhost:8080/admin/ |
+| User dashboard | http://localhost:8080/realms/master/account/#/ |
+| Well-known config | http://localhost:8080/realms/master/.well-known/openid-configuration |

--- a/docs/d7.md
+++ b/docs/d7.md
@@ -1,17 +1,93 @@
-# Backups
+# Directus (d7)
 
-In order for `scripts/backup_d7_postgres.js` to run, you need to install the `aws cli` system wide.
+## Backups
 
-```
+The `scripts/backup_d7_postgres.js` script requires the AWS CLI installed system-wide:
+
+```bash
 sudo snap install aws-cli --classic
 aws configure
 # enter the access and secret key
 ```
 
-**Note:** to reduce filesize, revisions are NOT backed up
+To reduce file size, revisions are not backed up by default. Use `--full` to include them.
 
-Then, to automate it, set up a cron job similar to this:
+Automate with a cron job:
 
-```
+```bash
 0 0 * * SUN cd /home/ubuntu/frg/scripts && /home/ubuntu/.nvm/versions/node/v18.20.5/bin/node backup_d7_postgres.js
+```
+
+See [scripts/README.md](../scripts/README.md) for full backup and restore documentation.
+
+## Translations
+
+Food pantry data is translated using LibreTranslate. Translations are stored in a `foodPantries_translations` junction table via Directus's native translations system.
+
+### Translated fields
+
+| Field | Strategy |
+|---|---|
+| `name` | Plain text translation |
+| `notes` | Markdown converted to HTML, translated, then converted back to preserve formatting |
+| `hours` | JSON structure preserved (`days`, `timeStart`, `timeEnd` unchanged); only the optional `notes` within each entry is translated |
+
+### Languages
+
+Managed in the `languages` collection. Currently: `en`, `es`, `ko`, `id`. Adding a new language to this collection automatically includes it in translation scripts and export flows.
+
+### Running translations
+
+```bash
+yarn translate:foodPantries
+```
+
+The script is idempotent — it skips translations that are already up to date. A translation is considered stale when the food pantry's `lastVerified` is newer than the translation's `lastUpdated`.
+
+See [scripts/README.md](../scripts/README.md) for details.
+
+## Directus Flows
+
+### Dump Food Pantries All Languages
+
+| | |
+|---|---|
+| **Trigger** | Manual / Webhook (POST) |
+| **Flow ID** | `c912465d-74b5-4575-9a22-a87cf01b6756` |
+
+Reads all entries from the `languages` collection and triggers "Dump Open Food Pantries by Language" for each one, producing one JSON export per language.
+
+```bash
+curl -X POST http://localhost:8055/flows/trigger/c912465d-74b5-4575-9a22-a87cf01b6756 \
+  -H "Authorization: Bearer <static-token>"
+```
+
+### Dump Open Food Pantries by Language
+
+| | |
+|---|---|
+| **Trigger** | Operation (called by parent flow) |
+| **Flow ID** | `7a33b3f0-ddbb-4af2-a85f-2737ed4b1d60` |
+
+Exports all food pantries with `status: "open"` for a given language:
+
+1. **Read Data** — fetches all open food pantries with translations
+2. **Scrub Data** — whitelists fields, strips private phone numbers and emails, swaps in translated fields for the requested language
+3. **Save File** — saves as `foodPantriesOpen.{lang}.json` to Directus files
+
+### Output files
+
+| File | Language |
+|---|---|
+| `foodPantriesOpen.en.json` | English (source data, no translations applied) |
+| `foodPantriesOpen.es.json` | Spanish |
+| `foodPantriesOpen.ko.json` | Korean |
+| `foodPantriesOpen.id.json` | Indonesian |
+
+### Version tracking
+
+Flows live in the database and are not tracked in git by default. Use the Directus schema snapshot to export them:
+
+```bash
+docker exec d7_directus npx directus schema snapshot --yes /directus/uploads/snapshot.yaml
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,4 @@
-# Backup & Restore Scripts
-
-Scripts for backing up and restoring the Directus (d7) instance, including database, uploads, and extensions.
+# Scripts
 
 ## Prerequisites
 
@@ -8,16 +6,11 @@ Scripts for backing up and restoring the Directus (d7) instance, including datab
 - Node.js dependencies installed (`yarn install` from project root)
 - AWS credentials configured for S3 uploads (optional — backups are kept locally if S3 fails)
 
-## Scripts
+## Backup & Restore
 
 ### `backup_full.js` — Full Backup
 
-Creates a single `.tar.gz` archive containing:
-- **Database**: `pg_dump` of the full PostgreSQL database (custom format)
-- **Uploads**: All files from `/directus/uploads`
-- **Extensions**: All extensions (with `node_modules` stripped)
-
-Uploads the archive to S3 at `s3://frg-directus-backups/full-backups/`. If S3 upload fails, the archive is kept locally at `/tmp/`.
+Creates a single `.tar.gz` archive containing the database, uploads, and extensions (with `node_modules` stripped). Uploads the archive to S3 at `s3://frg-directus-backups/full-backups/`. If S3 fails, the archive is kept locally at `/tmp/`.
 
 ```bash
 yarn backup:full
@@ -34,51 +27,20 @@ yarn backup:db:full     # includes all tables
 
 ### `restore_full.js` — Full Restore
 
-Restores from a `.tar.gz` archive created by `backup_full.js`. This will:
-1. Stop the Directus container
-2. Drop and recreate the database
-3. Restore the database from the dump
-4. Replace uploads and extensions on the host (volume-mounted)
-5. Restart Directus
+Restores from a `.tar.gz` archive created by `backup_full.js`:
+
+1. Extracts the archive
+2. Stops the Directus container
+3. Drops and recreates the database
+4. Restores the database dump
+5. Replaces uploads and extensions on the host (volume-mounted)
+6. Restarts Directus
 
 ```bash
 yarn restore:full <path-to-backup.tar.gz>
 ```
 
-### `translate_food_pantries.js` — Translate Food Pantries
-
-Translates the `name`, `notes`, and `hours` fields for all food pantries into the languages defined in the `languages` collection.
-
-- **name**: Translated as plain text
-- **notes**: Markdown is converted to HTML, translated (preserving tags), then converted back to markdown
-- **hours**: JSON structure is preserved (`days`, `timeStart`, `timeEnd` unchanged), only the optional `notes` field within each entry is translated
-
-The script is idempotent — it skips translations that are already up to date. A translation is considered stale when the food pantry's `lastVerified` timestamp is newer than the translation's `lastUpdated` timestamp.
-
-```bash
-yarn translate:foodPantries
-```
-
-Requires:
-- Directus running locally with a static token configured
-- LibreTranslate running (default: `http://localhost:5000`)
-- Languages populated in the `languages` collection
-
-## Environment Variables
-
-Set in `env/d7.env`:
-
-| Variable | Description |
-|---|---|
-| `D7_POSTGRES_DB` | PostgreSQL database name |
-| `D7_POSTGRES_USER` | PostgreSQL user |
-| `BACKUP_BUCKET_NAME` | S3 bucket for storing backups |
-| `BACKUP_REGION` | AWS region for the S3 bucket |
-| `D7_DIRECTUS_STATIC_TOKEN` | Static API token for Directus admin user |
-| `LIBRETRANSLATE_URL` | LibreTranslate endpoint (default: `http://localhost:5000`) |
-| `LIBRETRANSLATE_API_KEY` | LibreTranslate API key (optional, if auth is required) |
-
-## Archive Structure
+### Archive structure
 
 ```
 backup.tar.gz
@@ -86,3 +48,42 @@ backup.tar.gz
   uploads/          # Directus uploaded files
   extensions/       # Directus extensions (no node_modules)
 ```
+
+## Translation
+
+### `translate_food_pantries.js` — Translate Food Pantries
+
+Translates the `name`, `notes`, and `hours` fields for all food pantries into the languages defined in the `languages` collection.
+
+| Field | Strategy |
+|---|---|
+| `name` | Plain text translation |
+| `notes` | Markdown converted to HTML, translated, then converted back to preserve formatting |
+| `hours` | JSON structure preserved; only the optional `notes` within each entry is translated |
+
+The script is idempotent. It skips translations that are already up to date. A translation is considered stale when the food pantry's `lastVerified` is newer than the translation's `lastUpdated`.
+
+```bash
+yarn translate:foodPantries
+```
+
+Requires:
+- Directus running with a static token configured
+- LibreTranslate running (default: `http://localhost:5000`)
+- Languages populated in the `languages` collection
+
+## Environment Variables
+
+All set in `env/d7.env`:
+
+| Variable | Description |
+|---|---|
+| `D7_POSTGRES_DB` | PostgreSQL database name |
+| `D7_POSTGRES_USER` | PostgreSQL user |
+| `BACKUP_BUCKET_NAME` | S3 bucket for storing backups |
+| `BACKUP_REGION` | AWS region for the S3 bucket |
+| `D7_DIRECTUS_AWS_S3_KEY_ID` | AWS access key ID for S3 |
+| `D7_DIRECTUS_AWS_S3_ACCESS_KEY` | AWS secret access key for S3 |
+| `D7_DIRECTUS_STATIC_TOKEN` | Static API token for Directus admin user |
+| `LIBRETRANSLATE_URL` | LibreTranslate endpoint (default: `http://localhost:5000`) |
+| `LIBRETRANSLATE_API_KEY` | LibreTranslate API key (optional, if auth is required) |


### PR DESCRIPTION
## Summary
- Rewrites `docs/auth.md` — restructured Keycloak setup into clear numbered steps with reference tables
- Rewrites `docs/d7.md` — adds translations, Directus flows, and schema snapshot documentation
- Rewrites `scripts/README.md` — consistent formatting, adds AWS credential env vars

All three files now use the same voice and structure (tables, code blocks, section headers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)