### PR TITLE
Add schema/flow export and translation --force flag

### DIFF
--- a/d7/flows.json
+++ b/d7/flows.json
@@ -1,0 +1,742 @@
+[
+  {
+    "id": "18e2267d-34d0-4e71-9686-c740b01bf571",
+    "name": "Queue Job",
+    "icon": "flowsheet",
+    "color": null,
+    "description": "queue a translation job in mq",
+    "status": "active",
+    "trigger": "operation",
+    "accountability": "all",
+    "options": {
+      "return": "$last"
+    },
+    "operation": "a4d87c59-b933-40df-9067-c1a467bf6d5e",
+    "date_created": "2025-01-19T01:22:19.844Z",
+    "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab",
+    "operations": [
+      {
+        "id": "a4d87c59-b933-40df-9067-c1a467bf6d5e",
+        "name": "BullMQ - Queue Job",
+        "key": "operation_queue_bullmq_job_3njry",
+        "type": "operation-queue-bullmq-job",
+        "position_x": 19,
+        "position_y": 1,
+        "options": {},
+        "resolve": null,
+        "reject": null,
+        "flow": "18e2267d-34d0-4e71-9686-c740b01bf571",
+        "date_created": "2025-01-27T03:10:26.709Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      }
+    ]
+  },
+  {
+    "id": "384eeae1-3ea8-4034-bb1f-91f7d3209ec7",
+    "name": "Sync Last Attempted Verify",
+    "icon": "watch",
+    "color": "#6644FF",
+    "description": null,
+    "status": "active",
+    "trigger": "event",
+    "accountability": null,
+    "options": {
+      "type": "action",
+      "scope": [
+        "items.create"
+      ],
+      "collections": [
+        "updateCrewLogs"
+      ]
+    },
+    "operation": "ee7567b9-cd96-4673-9c3c-7b335fe8206f",
+    "date_created": "2025-03-03T03:37:32.766Z",
+    "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab",
+    "operations": [
+      {
+        "id": "2d84dac1-dd2f-47d3-a5c6-fccc5fdbd1b6",
+        "name": "Update Data",
+        "key": "item_update_nc5h2",
+        "type": "item-update",
+        "position_x": 94,
+        "position_y": 13,
+        "options": {
+          "payload": {
+            "lastVerified": "{{timestamp}}"
+          },
+          "collection": "foodPantries",
+          "query": {
+            "filter": {
+              "id": {
+                "_eq": "{{$trigger.payload.foodPantry}}"
+              }
+            }
+          },
+          "permissions": "$full"
+        },
+        "resolve": null,
+        "reject": null,
+        "flow": "384eeae1-3ea8-4034-bb1f-91f7d3209ec7",
+        "date_created": "2025-03-04T19:16:50.504Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      },
+      {
+        "id": "33a970f5-87f5-4673-83d7-a88be0c8151a",
+        "name": "Condition",
+        "key": "is_food_pantry_logged",
+        "type": "condition",
+        "position_x": 37,
+        "position_y": 1,
+        "options": {
+          "filter": {
+            "$trigger": {
+              "payload": {
+                "foodPantry": {
+                  "_null": true
+                }
+              }
+            }
+          }
+        },
+        "resolve": null,
+        "reject": "bb74c235-deb9-4a48-9b2e-9806e5df94f7",
+        "flow": "384eeae1-3ea8-4034-bb1f-91f7d3209ec7",
+        "date_created": "2025-03-04T14:55:59.577Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      },
+      {
+        "id": "b19dc452-0126-4817-82eb-3877fea3b878",
+        "name": "Condition",
+        "key": "is_food_pantry__call_verified",
+        "type": "condition",
+        "position_x": 76,
+        "position_y": 14,
+        "options": {
+          "filter": {
+            "$trigger": {
+              "payload": {
+                "level": {
+                  "_eq": "verified"
+                }
+              }
+            }
+          }
+        },
+        "resolve": "2d84dac1-dd2f-47d3-a5c6-fccc5fdbd1b6",
+        "reject": null,
+        "flow": "384eeae1-3ea8-4034-bb1f-91f7d3209ec7",
+        "date_created": "2025-03-04T19:16:50.519Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      },
+      {
+        "id": "bb74c235-deb9-4a48-9b2e-9806e5df94f7",
+        "name": "Update Data",
+        "key": "item_update_mn8uk",
+        "type": "item-update",
+        "position_x": 56,
+        "position_y": 15,
+        "options": {
+          "collection": "foodPantries",
+          "payload": {
+            "lastAttemptedVerify": "{{timestamp}}"
+          },
+          "query": {
+            "filter": {
+              "id": {
+                "_eq": "{{$trigger.payload.foodPantry}}"
+              }
+            }
+          },
+          "permissions": "$full"
+        },
+        "resolve": "b19dc452-0126-4817-82eb-3877fea3b878",
+        "reject": null,
+        "flow": "384eeae1-3ea8-4034-bb1f-91f7d3209ec7",
+        "date_created": "2025-03-04T14:55:59.570Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      },
+      {
+        "id": "ee7567b9-cd96-4673-9c3c-7b335fe8206f",
+        "name": "inject timestamp",
+        "key": "timestamp",
+        "type": "exec",
+        "position_x": 19,
+        "position_y": 1,
+        "options": {
+          "code": "module.exports = async function(data) {\n\treturn (new Date()).toISOString();\n}"
+        },
+        "resolve": "33a970f5-87f5-4673-83d7-a88be0c8151a",
+        "reject": null,
+        "flow": "384eeae1-3ea8-4034-bb1f-91f7d3209ec7",
+        "date_created": "2025-03-04T14:48:18.498Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      }
+    ]
+  },
+  {
+    "id": "5816f3ca-53c1-4dfb-8d88-00c838fc19e9",
+    "name": "Build Communities",
+    "icon": "flowsheet",
+    "color": null,
+    "description": "build all community pages",
+    "status": "active",
+    "trigger": "manual",
+    "accountability": "activity",
+    "options": {
+      "requireSelection": false,
+      "collections": [
+        "communities"
+      ]
+    },
+    "operation": "a50114a3-288a-477b-b05f-fe3bda54ae6e",
+    "date_created": "2025-01-19T01:22:20.117Z",
+    "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab",
+    "operations": [
+      {
+        "id": "5b77ddc9-762e-4cd6-b2ae-053481d107ac",
+        "name": "Build Community",
+        "key": "buildCommunity",
+        "type": "trigger",
+        "position_x": 37,
+        "position_y": 1,
+        "options": {
+          "flow": "963537d8-2d0e-4c00-b7ce-82cc1d4c5432",
+          "payload": "{{ $last }}"
+        },
+        "resolve": null,
+        "reject": null,
+        "flow": "5816f3ca-53c1-4dfb-8d88-00c838fc19e9",
+        "date_created": "2025-01-19T01:22:20.144Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      },
+      {
+        "id": "a50114a3-288a-477b-b05f-fe3bda54ae6e",
+        "name": "Read Data",
+        "key": "item_read_am7l5",
+        "type": "item-read",
+        "position_x": 19,
+        "position_y": 1,
+        "options": {
+          "collection": "communities",
+          "query": {
+            "sort": "name"
+          },
+          "permissions": "14fcaae6-5805-4f57-8fdf-859b829f8b54"
+        },
+        "resolve": "5b77ddc9-762e-4cd6-b2ae-053481d107ac",
+        "reject": null,
+        "flow": "5816f3ca-53c1-4dfb-8d88-00c838fc19e9",
+        "date_created": "2025-01-19T01:22:20.153Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      }
+    ]
+  },
+  {
+    "id": "75ae13e0-5dbb-4b24-9896-84fba30fff98",
+    "name": "Manual: Dump Food Pantries All Languages",
+    "icon": "translate",
+    "color": null,
+    "description": "Manually trigger food pantries dump for all languages",
+    "status": "active",
+    "trigger": "manual",
+    "accountability": "all",
+    "options": null,
+    "operation": "66d4576d-1960-4a12-b4e9-343ea31bfed5",
+    "date_created": "2026-04-02T19:05:21.421Z",
+    "user_created": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "operations": [
+      {
+        "id": "2d17f32c-5e20-4c89-a141-d55e2f575e76",
+        "name": "Trigger Dump per Language",
+        "key": "trigger_dump",
+        "type": "trigger",
+        "position_x": 37,
+        "position_y": 1,
+        "options": {
+          "flow": "7a33b3f0-ddbb-4af2-a85f-2737ed4b1d60",
+          "payload": "{{ $last }}"
+        },
+        "resolve": null,
+        "reject": null,
+        "flow": "75ae13e0-5dbb-4b24-9896-84fba30fff98",
+        "date_created": "2026-04-02T19:05:21.508Z",
+        "user_created": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+      },
+      {
+        "id": "66d4576d-1960-4a12-b4e9-343ea31bfed5",
+        "name": "Read Languages",
+        "key": "read_languages",
+        "type": "item-read",
+        "position_x": 19,
+        "position_y": 1,
+        "options": {
+          "collection": "languages",
+          "query": {
+            "fields": [
+              "code"
+            ],
+            "limit": -1
+          },
+          "permissions": "$full"
+        },
+        "resolve": "2d17f32c-5e20-4c89-a141-d55e2f575e76",
+        "reject": null,
+        "flow": "75ae13e0-5dbb-4b24-9896-84fba30fff98",
+        "date_created": "2026-04-02T19:05:21.470Z",
+        "user_created": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+      }
+    ]
+  },
+  {
+    "id": "7a33b3f0-ddbb-4af2-a85f-2737ed4b1d60",
+    "name": "Dump Open Food Pantries by Language",
+    "icon": "bolt",
+    "color": null,
+    "description": "Exports all open food pantries for a given language, using translated fields when available",
+    "status": "active",
+    "trigger": "operation",
+    "accountability": "all",
+    "options": {},
+    "operation": "395d8aee-34f6-4048-8132-e81a1c5e1a42",
+    "date_created": "2025-04-08T21:09:12.172Z",
+    "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab",
+    "operations": [
+      {
+        "id": "395d8aee-34f6-4048-8132-e81a1c5e1a42",
+        "name": "Read Data",
+        "key": "getData",
+        "type": "item-read",
+        "position_x": 19,
+        "position_y": 1,
+        "options": {
+          "collection": "foodPantries",
+          "query": {
+            "filter": {
+              "status": {
+                "_eq": "open"
+              }
+            },
+            "fields": [
+              "*",
+              "translations.*"
+            ],
+            "limit": -1
+          },
+          "permissions": "$full"
+        },
+        "resolve": "f21b2ff0-68b2-4d08-8046-2c9b5c0f2027",
+        "reject": null,
+        "flow": "7a33b3f0-ddbb-4af2-a85f-2737ed4b1d60",
+        "date_created": "2025-04-08T21:12:07.492Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      },
+      {
+        "id": "51f6888e-350c-4edb-bbc6-34142c876f8a",
+        "name": "Save File",
+        "key": "save_file_gxtio",
+        "type": "saveFile",
+        "position_x": 55,
+        "position_y": 1,
+        "options": {
+          "filename": "foodPantriesOpen.json"
+        },
+        "resolve": null,
+        "reject": null,
+        "flow": "7a33b3f0-ddbb-4af2-a85f-2737ed4b1d60",
+        "date_created": "2026-01-05T21:41:22.991Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      },
+      {
+        "id": "5dab52f6-9540-41a9-8174-e4635b2b34be",
+        "name": "Run Script",
+        "key": "exec_s517r",
+        "type": "exec",
+        "position_x": 55,
+        "position_y": 1,
+        "options": {
+          "code": "module.exports = async function(data) {\n  const language = (data.$trigger.body && data.$trigger.body.language) || (data.$trigger && data.$trigger.code);\n  return {\n    data: data.$last,\n    filename: language ? \"foodPantriesOpen.\" + language + \".json\" : \"foodPantriesOpen.json\"\n  };\n}"
+        },
+        "resolve": "ef783f3d-8b44-4b31-b9f3-7357c83675c9",
+        "reject": null,
+        "flow": "7a33b3f0-ddbb-4af2-a85f-2737ed4b1d60",
+        "date_created": "2026-01-05T21:42:57.819Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      },
+      {
+        "id": "ef783f3d-8b44-4b31-b9f3-7357c83675c9",
+        "name": "Save File",
+        "key": "save_file_3s5y6",
+        "type": "saveFile",
+        "position_x": 73,
+        "position_y": 1,
+        "options": {
+          "filename": "{{$last.filename}}",
+          "folder": "be5f2374-dc9f-48f9-832b-9926ed8c8bc3"
+        },
+        "resolve": null,
+        "reject": null,
+        "flow": "7a33b3f0-ddbb-4af2-a85f-2737ed4b1d60",
+        "date_created": "2026-01-05T21:42:57.806Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      },
+      {
+        "id": "f21b2ff0-68b2-4d08-8046-2c9b5c0f2027",
+        "name": "Run Script",
+        "key": "scrubData",
+        "type": "exec",
+        "position_x": 37,
+        "position_y": 1,
+        "options": {
+          "code": "const exportFields = {\n  id: null,\n  name: null,\n  status: null,\n  notes: null,\n  streetAddress: null,\n  addressLocality: null,\n  addressRegion: null,\n  postalCode: null,\n  addressCountry: null,\n  geolocation: null,\n  hours: null,\n  phoneNumbers: (ps) => ps ? ps.filter((p) => p.isPrivate === false) : ps,\n  emailAddresses: (es) => es ? es.filter((e) => e.isPrivate === false) : es,\n  website: null,\n  idRequired: null,\n  lastVerified: null,\n  type: null,\n  dietaryAccomodations: null\n}\n\nconst translatableFields = [\"name\", \"notes\", \"hours\"];\n\nmodule.exports = async function(data) {\n  const language = (data.$trigger.body && data.$trigger.body.language) || (data.$trigger && data.$trigger.code);\n\n  return data.$last.map((record) => {\n    const translation = language && record.translations\n      ? record.translations.find((t) => t.languages_code === language)\n      : null;\n\n    let payload = {};\n    Object.keys(exportFields).forEach((f) => {\n      let value = record[f];\n      if (translation && translatableFields.includes(f) && translation[f] != null) {\n        value = translation[f];\n      }\n      payload[f] = exportFields[f] === null ? value : exportFields[f](value);\n    });\n    return payload;\n  });\n}"
+        },
+        "resolve": "5dab52f6-9540-41a9-8174-e4635b2b34be",
+        "reject": null,
+        "flow": "7a33b3f0-ddbb-4af2-a85f-2737ed4b1d60",
+        "date_created": "2025-04-08T21:12:07.459Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      }
+    ]
+  },
+  {
+    "id": "963537d8-2d0e-4c00-b7ce-82cc1d4c5432",
+    "name": "Build Community",
+    "icon": "build",
+    "color": null,
+    "description": "build a single community",
+    "status": "active",
+    "trigger": "operation",
+    "accountability": "activity",
+    "options": {
+      "return": "transform_pug"
+    },
+    "operation": "77e85902-3abf-42e5-9964-80748ef54c5a",
+    "date_created": "2025-01-19T01:22:20.271Z",
+    "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab",
+    "operations": [
+      {
+        "id": "389936ae-e4ba-4a99-87b5-19bbc0739851",
+        "name": "Read Data",
+        "key": "get_farmers_markets",
+        "type": "item-read",
+        "position_x": 21,
+        "position_y": 19,
+        "options": {
+          "collection": "farmersMarkets",
+          "permissions": "14fcaae6-5805-4f57-8fdf-859b829f8b54",
+          "query": {
+            "filter": {
+              "geolocation": {
+                "_intersects_bbox": "{{$trigger.geometry}}"
+              }
+            }
+          }
+        },
+        "resolve": "91396fda-b765-4e9c-8104-8b7f420dc754",
+        "reject": null,
+        "flow": "963537d8-2d0e-4c00-b7ce-82cc1d4c5432",
+        "date_created": "2025-01-19T01:22:20.450Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      },
+      {
+        "id": "3fab0d6a-4c7b-461a-bf99-4adae7bab2a5",
+        "name": "Get Social Services",
+        "key": "get_social_services",
+        "type": "item-read",
+        "position_x": 3,
+        "position_y": 19,
+        "options": {
+          "collection": "socialServices",
+          "query": {
+            "filter": {
+              "geolocation": {
+                "_intersects_bbox": "{{$trigger.geometry}}"
+              }
+            }
+          },
+          "permissions": "14fcaae6-5805-4f57-8fdf-859b829f8b54"
+        },
+        "resolve": "389936ae-e4ba-4a99-87b5-19bbc0739851",
+        "reject": null,
+        "flow": "963537d8-2d0e-4c00-b7ce-82cc1d4c5432",
+        "date_created": "2025-01-19T01:22:20.459Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      },
+      {
+        "id": "646f53e0-b00f-4b8a-8109-c169d0363768",
+        "name": "Upload to S3",
+        "key": "operation_upload_to_s3_6b3xp",
+        "type": "operation-upload-to-s3",
+        "position_x": 21,
+        "position_y": 55,
+        "options": {},
+        "resolve": "ba4329b9-826e-4e13-9c9e-19c995a508c0",
+        "reject": null,
+        "flow": "963537d8-2d0e-4c00-b7ce-82cc1d4c5432",
+        "date_created": "2025-01-19T01:22:20.389Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      },
+      {
+        "id": "6e549b6a-6914-40de-9375-541db453a757",
+        "name": "Transform Payload",
+        "key": "transform_xy28d",
+        "type": "transform",
+        "position_x": 21,
+        "position_y": 37,
+        "options": {
+          "json": {
+            "data": {
+              "community": "{{ $trigger }}",
+              "farmersMarkets": "{{ get_farmers_markets }}",
+              "foodPantries": "{{ get_food_pantries }}",
+              "retailFoodStores": "{{ get_retail_food_stores }}",
+              "socialServices": "{{ get_social_services }}",
+              "communityFridges": "{{ get_community_fridges }}"
+            },
+            "templates": "{{ get_template }}"
+          }
+        },
+        "resolve": "e54be7b5-608e-45be-8b2a-7de868e223e6",
+        "reject": null,
+        "flow": "963537d8-2d0e-4c00-b7ce-82cc1d4c5432",
+        "date_created": "2025-01-19T01:22:20.431Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      },
+      {
+        "id": "7640c2a0-0a25-44d0-982e-e620b29ab3d2",
+        "name": "Trigger Flow",
+        "key": "trigger_usrid",
+        "type": "trigger",
+        "position_x": 3,
+        "position_y": 73,
+        "options": {
+          "flow": "18e2267d-34d0-4e71-9686-c740b01bf571",
+          "payload": "{{ $last }}"
+        },
+        "resolve": null,
+        "reject": null,
+        "flow": "963537d8-2d0e-4c00-b7ce-82cc1d4c5432",
+        "date_created": "2025-01-19T01:22:20.320Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      },
+      {
+        "id": "77e85902-3abf-42e5-9964-80748ef54c5a",
+        "name": "Get Food Pantries",
+        "key": "get_food_pantries",
+        "type": "item-read",
+        "position_x": 21,
+        "position_y": 1,
+        "options": {
+          "collection": "foodPantries",
+          "query": {
+            "filter": {
+              "geolocation": {
+                "_intersects_bbox": "{{$trigger.geometry}}"
+              }
+            }
+          },
+          "permissions": "14fcaae6-5805-4f57-8fdf-859b829f8b54"
+        },
+        "resolve": "ed70bb84-a616-4c3a-bb3e-cf2391218f37",
+        "reject": null,
+        "flow": "963537d8-2d0e-4c00-b7ce-82cc1d4c5432",
+        "date_created": "2025-01-19T01:22:20.490Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      },
+      {
+        "id": "91396fda-b765-4e9c-8104-8b7f420dc754",
+        "name": "Read Data",
+        "key": "get_template",
+        "type": "item-read",
+        "position_x": 3,
+        "position_y": 37,
+        "options": {
+          "collection": "templates",
+          "query": {
+            "filter": {
+              "_and": [
+                {
+                  "handle": {
+                    "_eq": "FPC Web"
+                  }
+                }
+              ]
+            },
+            "sort": "order"
+          },
+          "permissions": "14fcaae6-5805-4f57-8fdf-859b829f8b54"
+        },
+        "resolve": "6e549b6a-6914-40de-9375-541db453a757",
+        "reject": null,
+        "flow": "963537d8-2d0e-4c00-b7ce-82cc1d4c5432",
+        "date_created": "2025-01-19T01:22:20.440Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      },
+      {
+        "id": "ba4329b9-826e-4e13-9c9e-19c995a508c0",
+        "name": "Run Script",
+        "key": "exec_ttnbp",
+        "type": "exec",
+        "position_x": 39,
+        "position_y": 55,
+        "options": {
+          "code": "module.exports = async function(data) {\n    if(data.$trigger.translationTargets && data.$trigger.translationTargets.length > 0\n      && false // TODO: temporarily disable translations\n      ){\n    \treturn data.$trigger.translationTargets.map((target) => ({\n    \t    queue: 'fpc web i18n',\n    \t    name: data.$trigger.name,\n    \t    payload: {\n    \t    bucket: data.s3_config.bucket,\n    \t    key: data.s3_config.key,\n    \t    languages: {\n\t\t        source: 'en',\n    \t        target\n    \t    },\n                slug: data.s3_config.slug,\n        \t}\n        \t}));\n    }else{\n        // nothing to do\n        return [];\n    }\n}"
+        },
+        "resolve": "7640c2a0-0a25-44d0-982e-e620b29ab3d2",
+        "reject": null,
+        "flow": "963537d8-2d0e-4c00-b7ce-82cc1d4c5432",
+        "date_created": "2025-01-19T01:22:20.330Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      },
+      {
+        "id": "be393736-3133-4dca-afd0-e777842f445b",
+        "name": "Run Script",
+        "key": "s3_config",
+        "type": "exec",
+        "position_x": 3,
+        "position_y": 55,
+        "options": {
+          "code": "function generateTableOfContents(htmlString) {\n    const tocList = [];\n    const sectionRegex = /<section id=\"([^\"]+)\">\\s*<h\\d>(.*?)<\\/h\\d>(.*?)<\\/section>/gs;\n\n    let match;\n    while ((match = sectionRegex.exec(htmlString)) !== null) {\n        const sectionId = match[1];\n        const sectionTitle = match[2];\n        const nestedHtml = match[3];\n\n        // Create the TOC entry for the current section\n        let tocEntry = `<li><a href=\"#${sectionId}\">${sectionTitle}</a>`;\n\n        // Check for nested sections\n        const nestedSections = getNestedSections(nestedHtml);\n        if (nestedSections.length > 0) {\n            tocEntry += '<ul>';\n            nestedSections.forEach(nested => {\n                tocEntry += `<li><a href=\"#${nested.id}\">${nested.title}</a></li>`;\n            });\n            tocEntry += '</ul>';\n        }\n        tocEntry += '</li>';\n\n        tocList.push(tocEntry);\n    }\n\n    // Combine the TOC entries into an unordered list\n    const tocHtml = `<ul>${tocList.join('')}</ul>`;\n\n    // Replace [toc] in the original HTML string with the TOC\n    return htmlString.replace('[toc]', tocHtml);\n}\n\nfunction getNestedSections(nestedHtml) {\n    const nestedSections = [];\n    const nestedSectionRegex = /<section id=\"([^\"]+)\">\\s*<h\\d>(.*?)<\\/h\\d>/gs;\n\n    let match;\n    while ((match = nestedSectionRegex.exec(nestedHtml)) !== null) {\n        nestedSections.push({ id: match[1], title: match[2] });\n    }\n\n    return nestedSections;\n}\n\n\nfunction slugify(str) {\n  return str\n    .toLowerCase()                 // Convert to lowercase\n    .replace(/[^\\w\\s-]/g, '')      // Remove punctuation (non-word characters except spaces and -)\n    .replace(/[\\s-]+/g, '_');         // Replace spaces with underscores\n}\n\nmodule.exports = async function(data) {\n    const slug = slugify(data.$trigger.name);\n \treturn {\n        bucket: 'sm-frg-pages',\n        key: `${slug}_en.html`,\n        body: generateTableOfContents(data.$last),\n        contentType: 'text/html; charset=utf-8',\n        slug, // needed for i18n bullmq\n    }\n}"
+        },
+        "resolve": "646f53e0-b00f-4b8a-8109-c169d0363768",
+        "reject": null,
+        "flow": "963537d8-2d0e-4c00-b7ce-82cc1d4c5432",
+        "date_created": "2025-01-19T01:22:20.401Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      },
+      {
+        "id": "e54be7b5-608e-45be-8b2a-7de868e223e6",
+        "name": " Transform Pug",
+        "key": "transform_pug",
+        "type": "operation-transform-pug",
+        "position_x": 39,
+        "position_y": 37,
+        "options": {},
+        "resolve": "be393736-3133-4dca-afd0-e777842f445b",
+        "reject": null,
+        "flow": "963537d8-2d0e-4c00-b7ce-82cc1d4c5432",
+        "date_created": "2025-01-19T01:22:20.418Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      },
+      {
+        "id": "ed70bb84-a616-4c3a-bb3e-cf2391218f37",
+        "name": "Get Retail Food Stores",
+        "key": "get_retail_food_stores",
+        "type": "item-read",
+        "position_x": 39,
+        "position_y": 1,
+        "options": {
+          "collection": "retailFoodStores",
+          "query": {
+            "filter": {
+              "geolocation": {
+                "_intersects_bbox": "{{$trigger.geometry}}"
+              }
+            }
+          },
+          "permissions": "14fcaae6-5805-4f57-8fdf-859b829f8b54"
+        },
+        "resolve": "3fab0d6a-4c7b-461a-bf99-4adae7bab2a5",
+        "reject": null,
+        "flow": "963537d8-2d0e-4c00-b7ce-82cc1d4c5432",
+        "date_created": "2025-01-19T01:22:20.472Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      }
+    ]
+  },
+  {
+    "id": "c912465d-74b5-4575-9a22-a87cf01b6756",
+    "name": "Scheduled: Dump Food Pantries All Languages",
+    "icon": "translate",
+    "color": null,
+    "description": "Reads all languages and triggers a food pantries dump for each one",
+    "status": "active",
+    "trigger": "schedule",
+    "accountability": "all",
+    "options": {
+      "cron": "0 0 * * 0"
+    },
+    "operation": "61276b08-96f8-48d8-91fc-e9c19b026d23",
+    "date_created": "2026-04-02T01:13:12.689Z",
+    "user_created": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "operations": [
+      {
+        "id": "312b388a-be32-4508-92b0-8b4b34719feb",
+        "name": "Trigger Dump per Language",
+        "key": "trigger_dump",
+        "type": "trigger",
+        "position_x": 37,
+        "position_y": 1,
+        "options": {
+          "flow": "7a33b3f0-ddbb-4af2-a85f-2737ed4b1d60",
+          "payload": "{{ $last }}"
+        },
+        "resolve": null,
+        "reject": null,
+        "flow": "c912465d-74b5-4575-9a22-a87cf01b6756",
+        "date_created": "2026-04-02T01:45:47.662Z",
+        "user_created": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+      },
+      {
+        "id": "61276b08-96f8-48d8-91fc-e9c19b026d23",
+        "name": "Read Languages",
+        "key": "read_languages",
+        "type": "item-read",
+        "position_x": 19,
+        "position_y": 1,
+        "options": {
+          "collection": "languages",
+          "query": {
+            "fields": [
+              "code"
+            ],
+            "limit": -1
+          },
+          "permissions": "$full"
+        },
+        "resolve": "312b388a-be32-4508-92b0-8b4b34719feb",
+        "reject": null,
+        "flow": "c912465d-74b5-4575-9a22-a87cf01b6756",
+        "date_created": "2026-04-02T01:45:47.625Z",
+        "user_created": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+      }
+    ]
+  },
+  {
+    "id": "e3192bde-f031-45be-9895-f422ebf646f3",
+    "name": "Manual Build Communities",
+    "icon": "hand_gesture",
+    "color": null,
+    "description": "manually trigger a full build",
+    "status": "active",
+    "trigger": "manual",
+    "accountability": "all",
+    "options": {
+      "collections": [
+        "communities"
+      ],
+      "requireConfirmation": true,
+      "requireSelection": false
+    },
+    "operation": "fd8920f0-e4ec-4c11-a5a3-57a984e2f816",
+    "date_created": "2025-01-27T00:29:17.768Z",
+    "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab",
+    "operations": [
+      {
+        "id": "fd8920f0-e4ec-4c11-a5a3-57a984e2f816",
+        "name": "Trigger Flow",
+        "key": "trigger_fkafd",
+        "type": "trigger",
+        "position_x": 19,
+        "position_y": 1,
+        "options": {
+          "flow": "5816f3ca-53c1-4dfb-8d88-00c838fc19e9"
+        },
+        "resolve": null,
+        "reject": null,
+        "flow": "e3192bde-f031-45be-9895-f422ebf646f3",
+        "date_created": "2025-01-27T00:29:34.871Z",
+        "user_created": "720f01fd-c5b2-4e76-aa20-2c7434d266ab"
+      }
+    ]
+  }
+]

--- a/d7/snapshot.yaml
+++ b/d7/snapshot.yaml
@@ -1,0 +1,4718 @@
+version: 1
+directus: 11.5.1
+vendor: postgres
+collections:
+  - collection: communities
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: communities
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: communities
+  - collection: farmersMarkets
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: farmersMarkets
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: true
+    schema:
+      name: farmersMarkets
+  - collection: foodPantries
+    meta:
+      accountability: all
+      archive_app_filter: false
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: foodPantries
+      color: '#2ECDA7'
+      display_template: '{{name}}'
+      group: null
+      hidden: false
+      icon: food_bank
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: true
+    schema:
+      name: foodPantries
+  - collection: foodPantries_translations
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: foodPantries_translations
+      color: null
+      display_template: null
+      group: null
+      hidden: true
+      icon: translate
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: foodPantries_translations
+  - collection: languages
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: languages
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: translate
+      item_duplication_fields: null
+      note: Languages supported for translations
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: languages
+  - collection: retailFoodStores
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: retailFoodStores
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: storefront
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: true
+    schema:
+      name: retailFoodStores
+  - collection: socialServices
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: socialServices
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: handshake
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: true
+    schema:
+      name: socialServices
+  - collection: templates
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: archived
+      collapse: open
+      collection: templates
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: draft
+      versioning: false
+    schema:
+      name: templates
+  - collection: updateCrewLogs
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: updateCrewLogs
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: updateCrewLogs
+fields:
+  - collection: communities
+    field: id
+    type: uuid
+    meta:
+      collection: communities
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: communities
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: communities
+    field: name
+    type: string
+    meta:
+      collection: communities
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: communities
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: communities
+    field: geometry
+    type: geometry.MultiPolygon
+    meta:
+      collection: communities
+      conditions: null
+      display: null
+      display_options: null
+      field: geometry
+      group: null
+      hidden: false
+      interface: map
+      note: null
+      options:
+        defaultView:
+          bearing: 0
+          center:
+            lat: 5.684341886080802e-14
+            lng: 0.87460852015613
+          pitch: 0
+          zoom: -0.3706434003783813
+        geometryType: MultiPolygon
+      readonly: false
+      required: false
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: geometry
+      table: communities
+      data_type: MULTIPOLYGON
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: communities
+    field: translationTargets
+    type: json
+    meta:
+      collection: communities
+      conditions: null
+      display: null
+      display_options: null
+      field: translationTargets
+      group: null
+      hidden: false
+      interface: select-multiple-checkbox
+      note: null
+      options:
+        choices:
+          - text: Albanian
+            value: sq
+          - text: Arabic
+            value: ar
+          - text: Azerbaijani
+            value: az
+          - text: Bengali
+            value: bn
+          - text: Bulgarian
+            value: bg
+          - text: Catalan
+            value: ca
+          - text: Chinese
+            value: zh
+          - text: Czech
+            value: cs
+          - text: Danish
+            value: da
+          - text: Dutch
+            value: nl
+          - text: Estonian
+            value: et
+          - text: Finnish
+            value: fi
+          - text: French
+            value: fr
+          - text: German
+            value: de
+          - text: Greek
+            value: el
+          - text: Hebrew
+            value: he
+          - text: Hindi
+            value: hi
+          - text: Hungarian
+            value: hu
+          - text: Indonesian
+            value: id
+          - text: Irish
+            value: ga
+          - text: Italian
+            value: it
+          - text: Japanese
+            value: ja
+          - text: Korean
+            value: ko
+          - text: Latvian
+            value: lv
+          - text: Lithuanian
+            value: lt
+          - text: Malay
+            value: ms
+          - text: Norwegian
+            value: nb
+          - text: Persian
+            value: fa
+          - text: Polish
+            value: pl
+          - text: Portuguese
+            value: pt
+          - text: Romanian
+            value: ro
+          - text: Russian
+            value: ru
+          - text: Slovak
+            value: sk
+          - text: Slovenian
+            value: sl
+          - text: Spanish
+            value: es
+          - text: Swedish
+            value: sv
+          - text: Tagalog
+            value: tl
+          - text: Thai
+            value: th
+          - text: Turkish
+            value: tr
+          - text: Ukrainian
+            value: uk
+          - text: Urdu
+            value: ur
+          - text: Vietnamese
+            value: vi
+      readonly: false
+      required: false
+      sort: 4
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: translationTargets
+      table: communities
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: directus_settings
+    field: mv_hash
+    type: string
+    meta: null
+    schema:
+      name: mv_hash
+      table: directus_settings
+      data_type: character varying
+      default_value: ''
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: directus_settings
+    field: mv_ts
+    type: timestamp
+    meta: null
+    schema:
+      name: mv_ts
+      table: directus_settings
+      data_type: timestamp with time zone
+      default_value: '2020-01-01 00:00:00+00'
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: directus_settings
+    field: mv_locked
+    type: boolean
+    meta: null
+    schema:
+      name: mv_locked
+      table: directus_settings
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: farmersMarkets
+    field: id
+    type: uuid
+    meta:
+      collection: farmersMarkets
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: farmersMarkets
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: farmersMarkets
+    field: name
+    type: string
+    meta:
+      collection: farmersMarkets
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: farmersMarkets
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: farmersMarkets
+    field: streetAddress
+    type: string
+    meta:
+      collection: farmersMarkets
+      conditions: null
+      display: null
+      display_options: null
+      field: streetAddress
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: streetAddress
+      table: farmersMarkets
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: farmersMarkets
+    field: addressLocality
+    type: string
+    meta:
+      collection: farmersMarkets
+      conditions: null
+      display: null
+      display_options: null
+      field: addressLocality
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: addressLocality
+      table: farmersMarkets
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: farmersMarkets
+    field: addressRegion
+    type: string
+    meta:
+      collection: farmersMarkets
+      conditions: null
+      display: null
+      display_options: null
+      field: addressRegion
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: addressRegion
+      table: farmersMarkets
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: farmersMarkets
+    field: postalCode
+    type: string
+    meta:
+      collection: farmersMarkets
+      conditions: null
+      display: null
+      display_options: null
+      field: postalCode
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: postalCode
+      table: farmersMarkets
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: farmersMarkets
+    field: addressCountry
+    type: string
+    meta:
+      collection: farmersMarkets
+      conditions: null
+      display: null
+      display_options: null
+      field: addressCountry
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: addressCountry
+      table: farmersMarkets
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: farmersMarkets
+    field: geolocation
+    type: geometry.Point
+    meta:
+      collection: farmersMarkets
+      conditions: null
+      display: null
+      display_options: null
+      field: geolocation
+      group: null
+      hidden: false
+      interface: map
+      note: null
+      options:
+        defaultView:
+          bearing: 0
+          center:
+            lat: 0
+            lng: 0
+          pitch: 0
+          zoom: 0
+        geometryType: Point
+      readonly: false
+      required: false
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: geolocation
+      table: farmersMarkets
+      data_type: POINT
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: farmersMarkets
+    field: website
+    type: string
+    meta:
+      collection: farmersMarkets
+      conditions: null
+      display: null
+      display_options: null
+      field: website
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: website
+      table: farmersMarkets
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: farmersMarkets
+    field: lastVerified
+    type: dateTime
+    meta:
+      collection: farmersMarkets
+      conditions: null
+      display: null
+      display_options: null
+      field: lastVerified
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options:
+        use24: false
+      readonly: false
+      required: false
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: lastVerified
+      table: farmersMarkets
+      data_type: timestamp without time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: farmersMarkets
+    field: hours
+    type: json
+    meta:
+      collection: farmersMarkets
+      conditions: null
+      display: null
+      display_options: null
+      field: hours
+      group: null
+      hidden: false
+      interface: list
+      note: null
+      options:
+        addLabel: Create New
+        fields:
+          - field: days
+            meta:
+              display: null
+              field: days
+              interface: select-multiple-checkbox
+              options:
+                choices:
+                  - text: Monday
+                    value: Mo
+                  - text: Tuesday
+                    value: Tu
+                  - text: Wednesday
+                    value: We
+                  - text: Thursday
+                    value: Th
+                  - text: Friday
+                    value: Fr
+                  - text: Saturday
+                    value: Sa
+                  - text: Sunday
+                    value: Su
+                itemsShown: 7
+              type: json
+            name: days
+            type: json
+          - field: timeStart
+            meta:
+              field: timeStart
+              interface: datetime
+              options:
+                use24: false
+              type: time
+              width: half
+            name: timeStart
+            type: time
+          - field: timeEnd
+            meta:
+              field: timeEnd
+              interface: datetime
+              options:
+                use24: false
+              type: time
+              width: half
+            name: timeEnd
+            type: time
+          - field: notes
+            meta:
+              field: notes
+              interface: input-rich-text-md
+              options:
+                editorFont: monospace
+                toolbar:
+                  - heading
+                  - bold
+                  - italic
+                  - strikethrough
+                  - blockquote
+                  - bullist
+                  - numlist
+                  - table
+                  - link
+                  - empty
+              type: text
+              width: full
+            name: notes
+            type: text
+        template: '{{ days }} {{timeStart}}-{{timeEnd}}'
+      readonly: false
+      required: false
+      sort: 12
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: hours
+      table: farmersMarkets
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: id
+    type: uuid
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: foodPantries
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: name
+    type: string
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: foodPantries
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: status
+    type: string
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: Published
+            value: published
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Draft
+            value: draft
+          - background: var(--theme--warning-background)
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            text: Archived
+            value: archived
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Open
+            value: open
+          - text: Closed
+            value: closed
+          - text: Closed - Temporary
+            value: closed_temporary
+          - text: Unknown
+            value: unknown
+      readonly: false
+      required: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: status
+      table: foodPantries
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: notes
+    type: text
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: null
+      display_options: null
+      field: notes
+      group: null
+      hidden: false
+      interface: input-rich-text-md
+      note: null
+      options:
+        alphabetize: true
+      readonly: false
+      required: false
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: notes
+      table: foodPantries
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: streetAddress
+    type: string
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: null
+      display_options: null
+      field: streetAddress
+      group: null
+      hidden: false
+      interface: null
+      note: null
+      options:
+        trim: true
+      readonly: false
+      required: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: streetAddress
+      table: foodPantries
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: addressLocality
+    type: string
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: null
+      display_options: null
+      field: addressLocality
+      group: null
+      hidden: false
+      interface: input
+      note: City
+      options:
+        trim: true
+      readonly: false
+      required: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: addressLocality
+      table: foodPantries
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: addressRegion
+    type: string
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: null
+      display_options: null
+      field: addressRegion
+      group: null
+      hidden: false
+      interface: input
+      note: State
+      options:
+        trim: true
+      readonly: false
+      required: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: addressRegion
+      table: foodPantries
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: postalCode
+    type: string
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: null
+      display_options: null
+      field: postalCode
+      group: null
+      hidden: false
+      interface: input
+      note: Zipcode
+      options:
+        trim: true
+      readonly: false
+      required: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: postalCode
+      table: foodPantries
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: addressCountry
+    type: string
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: null
+      display_options: null
+      field: addressCountry
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options:
+        trim: true
+      readonly: false
+      required: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: addressCountry
+      table: foodPantries
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: geolocation
+    type: geometry.Point
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: null
+      display_options: null
+      field: geolocation
+      group: null
+      hidden: false
+      interface: map
+      note: null
+      options:
+        defaultView:
+          bearing: 0
+          center:
+            lat: -37.718592344657274
+            lng: 97.54922739369954
+          pitch: 0
+          zoom: 0
+        geometryType: Point
+      readonly: false
+      required: false
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: geolocation
+      table: foodPantries
+      data_type: POINT
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: hours
+    type: json
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: null
+      display_options: null
+      field: hours
+      group: null
+      hidden: false
+      interface: list
+      note: null
+      options:
+        addLabel: Create New
+        fields:
+          - field: days
+            meta:
+              display: null
+              field: days
+              interface: select-multiple-checkbox
+              options:
+                choices:
+                  - text: Monday
+                    value: Mo
+                  - text: Tuesday
+                    value: Tu
+                  - text: Wednesday
+                    value: We
+                  - text: Thursday
+                    value: Th
+                  - text: Friday
+                    value: Fr
+                  - text: Saturday
+                    value: Sa
+                  - text: Sunday
+                    value: Su
+                itemsShown: 7
+              type: json
+            name: days
+            type: json
+          - field: timeStart
+            meta:
+              field: timeStart
+              interface: datetime
+              options:
+                use24: false
+              type: time
+              width: half
+            name: timeStart
+            type: time
+          - field: timeEnd
+            meta:
+              field: timeEnd
+              interface: datetime
+              options:
+                use24: false
+              type: time
+              width: half
+            name: timeEnd
+            type: time
+          - field: notes
+            meta:
+              field: notes
+              interface: input-rich-text-md
+              options:
+                editorFont: monospace
+                toolbar:
+                  - heading
+                  - bold
+                  - italic
+                  - strikethrough
+                  - blockquote
+                  - bullist
+                  - numlist
+                  - table
+                  - link
+                  - empty
+              type: text
+              width: full
+            name: notes
+            type: text
+        template: '{{ days }} {{timeStart}}-{{timeEnd}} {{notes}}'
+      readonly: false
+      required: false
+      sort: 12
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: hours
+      table: foodPantries
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: phoneNumbers
+    type: json
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: null
+      display_options: null
+      field: phoneNumbers
+      group: null
+      hidden: false
+      interface: list
+      note: null
+      options:
+        fields:
+          - field: phoneNumber
+            meta:
+              field: phoneNumber
+              interface: input
+              options:
+                trim: true
+              type: string
+            name: phoneNumber
+            type: string
+          - field: isPrivate
+            meta:
+              display: null
+              field: isPrivate
+              interface: boolean
+              options:
+                label: Private
+              required: false
+              type: boolean
+            name: isPrivate
+            type: boolean
+          - field: notes
+            meta:
+              field: notes
+              interface: input
+              options:
+                trim: true
+              type: string
+            name: notes
+            type: string
+        template: '{{phoneNumber}}'
+      readonly: false
+      required: false
+      sort: 3
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: phoneNumbers
+      table: foodPantries
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: emailAddresses
+    type: json
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: null
+      display_options: null
+      field: emailAddresses
+      group: null
+      hidden: false
+      interface: list
+      note: null
+      options:
+        fields:
+          - field: email
+            meta:
+              field: email
+              interface: input
+              options:
+                iconLeft: null
+                trim: true
+              required: false
+              type: string
+            name: email
+            type: string
+          - field: isPrivate
+            meta:
+              display: null
+              field: isPrivate
+              interface: boolean
+              options:
+                label: Private
+              type: boolean
+            name: isPrivate
+            type: boolean
+          - field: notes
+            meta:
+              field: notes
+              interface: input
+              type: string
+            name: notes
+            type: string
+      readonly: false
+      required: false
+      sort: 13
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: emailAddresses
+      table: foodPantries
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: website
+    type: string
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: null
+      display_options: null
+      field: website
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: website
+      table: foodPantries
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: idRequired
+    type: boolean
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: null
+      display_options: null
+      field: idRequired
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options:
+        label: Required
+      readonly: false
+      required: true
+      sort: 15
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: idRequired
+      table: foodPantries
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: dietaryAccomodations
+    type: json
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: null
+      display_options: null
+      field: dietaryAccomodations
+      group: null
+      hidden: false
+      interface: select-multiple-checkbox
+      note: null
+      options:
+        choices:
+          - text: Halal
+            value: halal
+          - text: Kosher
+            value: kosher
+        itemsShown: 2
+      readonly: false
+      required: false
+      sort: 16
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: dietaryAccomodations
+      table: foodPantries
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: externalIds
+    type: json
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: null
+      display_options: null
+      field: externalIds
+      group: null
+      hidden: false
+      interface: list
+      note: null
+      options:
+        fields:
+          - field: agency
+            meta:
+              field: agency
+              interface: input
+              options:
+                trim: true
+              required: true
+              type: string
+              width: half
+            name: agency
+            type: string
+          - field: id
+            meta:
+              field: id
+              interface: input
+              options:
+                trim: true
+              required: true
+              type: string
+              width: half
+            name: id
+            type: string
+        sort: agency
+        template: '{{agency}}'
+      readonly: false
+      required: false
+      sort: 17
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: externalIds
+      table: foodPantries
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: lastVerified
+    type: dateTime
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: null
+      display_options: null
+      field: lastVerified
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options:
+        use24: false
+      readonly: false
+      required: false
+      sort: 18
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: lastVerified
+      table: foodPantries
+      data_type: timestamp without time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: type
+    type: string
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: null
+      display_options: null
+      field: type
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Food Pantry
+            value: foodPantry
+          - text: Soup Kitchen
+            value: soupKitchen
+          - text: Mobile Food Pantry
+            value: mobileFoodPantry
+          - text: Mobile Soup Kitchen
+            value: mobileSoupKitchen
+          - text: Mobile Market
+            value: mobileMarket
+      readonly: false
+      required: false
+      sort: 19
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: type
+      table: foodPantries
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: lastAttemptedVerify
+    type: dateTime
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: null
+      display_options: null
+      field: lastAttemptedVerify
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options:
+        use24: false
+      readonly: false
+      required: false
+      sort: 20
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: lastAttemptedVerify
+      table: foodPantries
+      data_type: timestamp without time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries
+    field: translations
+    type: alias
+    meta:
+      collection: foodPantries
+      conditions: null
+      display: translations
+      display_options: null
+      field: translations
+      group: null
+      hidden: false
+      interface: translations
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: null
+      special:
+        - translations
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+  - collection: foodPantries_translations
+    field: id
+    type: integer
+    meta:
+      collection: foodPantries_translations
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: null
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 1
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: foodPantries_translations
+      data_type: integer
+      default_value: nextval('"foodPantries_translations_id_seq"'::regclass)
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: true
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries_translations
+    field: name
+    type: string
+    meta:
+      collection: foodPantries_translations
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: Translated name
+      options: null
+      readonly: false
+      required: false
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: foodPantries_translations
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries_translations
+    field: notes
+    type: text
+    meta:
+      collection: foodPantries_translations
+      conditions: null
+      display: null
+      display_options: null
+      field: notes
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: Translated notes
+      options: null
+      readonly: false
+      required: false
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: notes
+      table: foodPantries_translations
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries_translations
+    field: hours
+    type: json
+    meta:
+      collection: foodPantries_translations
+      conditions: null
+      display: null
+      display_options: null
+      field: hours
+      group: null
+      hidden: false
+      interface: input-code
+      note: Translated hours
+      options:
+        language: json
+      readonly: false
+      required: false
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: hours
+      table: foodPantries_translations
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: foodPantries_translations
+    field: foodPantries_id
+    type: uuid
+    meta:
+      collection: foodPantries_translations
+      conditions: null
+      display: null
+      display_options: null
+      field: foodPantries_id
+      group: null
+      hidden: true
+      interface: null
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: foodPantries_id
+      table: foodPantries_translations
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: foodPantries
+      foreign_key_column: id
+  - collection: foodPantries_translations
+    field: languages_code
+    type: string
+    meta:
+      collection: foodPantries_translations
+      conditions: null
+      display: null
+      display_options: null
+      field: languages_code
+      group: null
+      hidden: true
+      interface: null
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: languages_code
+      table: foodPantries_translations
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: languages
+      foreign_key_column: code
+  - collection: foodPantries_translations
+    field: lastUpdated
+    type: timestamp
+    meta:
+      collection: foodPantries_translations
+      conditions: null
+      display: datetime
+      display_options: null
+      field: lastUpdated
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 7
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: lastUpdated
+      table: foodPantries_translations
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: languages
+    field: code
+    type: string
+    meta:
+      collection: languages
+      conditions: null
+      display: null
+      display_options: null
+      field: code
+      group: null
+      hidden: false
+      interface: input
+      note: Language code (e.g. en, es, fr)
+      options: null
+      readonly: false
+      required: false
+      sort: 1
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: code
+      table: languages
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: languages
+    field: name
+    type: string
+    meta:
+      collection: languages
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: Language name (e.g. English, Spanish)
+      options: null
+      readonly: false
+      required: false
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: languages
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: id
+    type: uuid
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: retailFoodStores
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: name
+    type: string
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: retailFoodStores
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: phoneNumbers
+    type: json
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: phoneNumbers
+      group: null
+      hidden: false
+      interface: list
+      note: null
+      options:
+        fields:
+          - field: phoneNumber
+            meta:
+              field: phoneNumber
+              interface: input
+              options:
+                trim: true
+              type: string
+            name: phoneNumber
+            type: string
+          - field: isPrivate
+            meta:
+              display: null
+              field: isPrivate
+              interface: boolean
+              options:
+                label: Private
+              required: false
+              type: boolean
+            name: isPrivate
+            type: boolean
+          - field: notes
+            meta:
+              field: notes
+              interface: input
+              options:
+                trim: true
+              type: string
+            name: notes
+            type: string
+        template: '{{phoneNumber}}'
+      readonly: false
+      required: false
+      sort: 4
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: phoneNumbers
+      table: retailFoodStores
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: streetAddress
+    type: string
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: streetAddress
+      group: null
+      hidden: false
+      interface: null
+      note: null
+      options:
+        trim: true
+      readonly: false
+      required: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: streetAddress
+      table: retailFoodStores
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: addressLocality
+    type: string
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: addressLocality
+      group: null
+      hidden: false
+      interface: input
+      note: City
+      options:
+        trim: true
+      readonly: false
+      required: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: addressLocality
+      table: retailFoodStores
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: addressRegion
+    type: string
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: addressRegion
+      group: null
+      hidden: false
+      interface: input
+      note: State
+      options:
+        trim: true
+      readonly: false
+      required: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: addressRegion
+      table: retailFoodStores
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: postalCode
+    type: string
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: postalCode
+      group: null
+      hidden: false
+      interface: input
+      note: Zipcode
+      options:
+        trim: true
+      readonly: false
+      required: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: postalCode
+      table: retailFoodStores
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: addressCountry
+    type: string
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: addressCountry
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options:
+        trim: true
+      readonly: false
+      required: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: addressCountry
+      table: retailFoodStores
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: hours
+    type: json
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: hours
+      group: null
+      hidden: false
+      interface: list
+      note: null
+      options:
+        addLabel: Create New
+        fields:
+          - field: days
+            meta:
+              display: null
+              field: days
+              interface: select-multiple-checkbox
+              options:
+                choices:
+                  - text: Monday
+                    value: Mo
+                  - text: Tuesday
+                    value: Tu
+                  - text: Wednesday
+                    value: We
+                  - text: Thursday
+                    value: Th
+                  - text: Friday
+                    value: Fr
+                  - text: Saturday
+                    value: Sa
+                  - text: Sunday
+                    value: Su
+                itemsShown: 7
+              type: json
+            name: days
+            type: json
+          - field: timeStart
+            meta:
+              field: timeStart
+              interface: datetime
+              type: time
+              width: half
+            name: timeStart
+            type: time
+          - field: timeEnd
+            meta:
+              field: timeEnd
+              interface: datetime
+              type: time
+              width: half
+            name: timeEnd
+            type: time
+          - field: notes
+            meta:
+              field: notes
+              interface: input-rich-text-md
+              options:
+                editorFont: monospace
+                toolbar:
+                  - heading
+                  - bold
+                  - italic
+                  - strikethrough
+                  - blockquote
+                  - bullist
+                  - numlist
+                  - table
+                  - link
+                  - empty
+              type: text
+              width: full
+            name: notes
+            type: text
+        template: '{{ days }} {{timeStart}}-{{timeEnd}}'
+      readonly: false
+      required: false
+      sort: 11
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: hours
+      table: retailFoodStores
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: website
+    type: string
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: website
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: website
+      table: retailFoodStores
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: canDeliver
+    type: boolean
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: canDeliver
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 13
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: canDeliver
+      table: retailFoodStores
+      data_type: boolean
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: notes
+    type: text
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: notes
+      group: null
+      hidden: false
+      interface: input-rich-text-md
+      note: null
+      options:
+        alphabetize: true
+      readonly: false
+      required: false
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: notes
+      table: retailFoodStores
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: snapAccepted
+    type: boolean
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: snapAccepted
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 15
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: snapAccepted
+      table: retailFoodStores
+      data_type: boolean
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: snapNotes
+    type: string
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: snapNotes
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 16
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: snapNotes
+      table: retailFoodStores
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: wicAccepted
+    type: boolean
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: wicAccepted
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 17
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: wicAccepted
+      table: retailFoodStores
+      data_type: boolean
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: wicNotes
+    type: string
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: wicNotes
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 18
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: wicNotes
+      table: retailFoodStores
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: lastVerified
+    type: dateTime
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: lastVerified
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options:
+        use24: false
+      readonly: false
+      required: false
+      sort: 21
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: lastVerified
+      table: retailFoodStores
+      data_type: timestamp without time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: geolocation
+    type: geometry.Point
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: geolocation
+      group: null
+      hidden: false
+      interface: map
+      note: null
+      options:
+        defaultView:
+          bearing: 0
+          center:
+            lat: -37.718592344657274
+            lng: 97.54922739369954
+          pitch: 0
+          zoom: 0
+        geometryType: Point
+      readonly: false
+      required: false
+      sort: 22
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: geolocation
+      table: retailFoodStores
+      data_type: POINT
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: externalIds
+    type: json
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: externalIds
+      group: null
+      hidden: false
+      interface: list
+      note: null
+      options:
+        fields:
+          - field: agency
+            meta:
+              field: agency
+              interface: input
+              options:
+                trim: true
+              required: true
+              type: string
+              width: half
+            name: agency
+            type: string
+          - field: id
+            meta:
+              field: id
+              interface: input
+              options:
+                trim: true
+              required: true
+              type: string
+              width: half
+            name: id
+            type: string
+        sort: agency
+        template: '{{agency}}'
+      readonly: false
+      required: false
+      sort: 23
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: externalIds
+      table: retailFoodStores
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: retailFoodStores
+    field: type
+    type: string
+    meta:
+      collection: retailFoodStores
+      conditions: null
+      display: null
+      display_options: null
+      field: type
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Grocery Store
+            value: groceryStore
+          - text: Supermarket
+            value: supermarket
+          - text: Produce Market
+            value: produceMarket
+          - text: Convenience Store
+            value: convenienceStore
+          - text: Deli
+            value: deli
+          - text: Bakery
+            value: bakery
+          - text: Farmers Market
+            value: farmersMarket
+          - text: market
+            value: Market
+      readonly: false
+      required: false
+      sort: 24
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: type
+      table: retailFoodStores
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: socialServices
+    field: id
+    type: uuid
+    meta:
+      collection: socialServices
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: socialServices
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: socialServices
+    field: name
+    type: string
+    meta:
+      collection: socialServices
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: socialServices
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: socialServices
+    field: streetAddress
+    type: string
+    meta:
+      collection: socialServices
+      conditions: null
+      display: null
+      display_options: null
+      field: streetAddress
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: streetAddress
+      table: socialServices
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: socialServices
+    field: addressLocality
+    type: string
+    meta:
+      collection: socialServices
+      conditions: null
+      display: null
+      display_options: null
+      field: addressLocality
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: addressLocality
+      table: socialServices
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: socialServices
+    field: addressRegion
+    type: string
+    meta:
+      collection: socialServices
+      conditions: null
+      display: null
+      display_options: null
+      field: addressRegion
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: addressRegion
+      table: socialServices
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: socialServices
+    field: postalCode
+    type: string
+    meta:
+      collection: socialServices
+      conditions: null
+      display: null
+      display_options: null
+      field: postalCode
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: postalCode
+      table: socialServices
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: socialServices
+    field: addressCountry
+    type: string
+    meta:
+      collection: socialServices
+      conditions: null
+      display: null
+      display_options: null
+      field: addressCountry
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: addressCountry
+      table: socialServices
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: socialServices
+    field: geolocation
+    type: geometry.Point
+    meta:
+      collection: socialServices
+      conditions: null
+      display: null
+      display_options: null
+      field: geolocation
+      group: null
+      hidden: false
+      interface: map
+      note: null
+      options:
+        defaultView:
+          bearing: 0
+          center:
+            lat: -37.718592344657274
+            lng: 97.54922739369954
+          pitch: 0
+          zoom: 0
+        geometryType: Point
+      readonly: false
+      required: false
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: geolocation
+      table: socialServices
+      data_type: POINT
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: socialServices
+    field: phoneNumbers
+    type: json
+    meta:
+      collection: socialServices
+      conditions: null
+      display: null
+      display_options: null
+      field: phoneNumbers
+      group: null
+      hidden: false
+      interface: list
+      note: null
+      options:
+        fields:
+          - field: phoneNumber
+            meta:
+              field: phoneNumber
+              interface: input
+              options:
+                trim: true
+              type: string
+            name: phoneNumber
+            type: string
+          - field: isPrivate
+            meta:
+              display: boolean
+              field: isPrivate
+              interface: boolean
+              type: boolean
+            name: isPrivate
+            type: boolean
+          - field: notes
+            meta:
+              field: notes
+              interface: input
+              options:
+                trim: true
+              type: string
+            name: notes
+            type: string
+        template: '{{phoneNumber}}'
+      readonly: false
+      required: false
+      sort: 9
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: phoneNumbers
+      table: socialServices
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: socialServices
+    field: emailAddresses
+    type: json
+    meta:
+      collection: socialServices
+      conditions: null
+      display: null
+      display_options: null
+      field: emailAddresses
+      group: null
+      hidden: false
+      interface: list
+      note: null
+      options:
+        fields:
+          - field: email
+            meta:
+              field: email
+              interface: input
+              options:
+                iconLeft: null
+                trim: true
+              required: false
+              type: string
+            name: email
+            type: string
+          - field: isPrivate
+            meta:
+              display: null
+              field: isPrivate
+              interface: boolean
+              options:
+                label: Private
+              type: boolean
+            name: isPrivate
+            type: boolean
+          - field: notes
+            meta:
+              field: notes
+              interface: input
+              type: string
+            name: notes
+            type: string
+      readonly: false
+      required: false
+      sort: 10
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: emailAddresses
+      table: socialServices
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: socialServices
+    field: website
+    type: string
+    meta:
+      collection: socialServices
+      conditions: null
+      display: null
+      display_options: null
+      field: website
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: website
+      table: socialServices
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: socialServices
+    field: lastVerified
+    type: dateTime
+    meta:
+      collection: socialServices
+      conditions: null
+      display: null
+      display_options: null
+      field: lastVerified
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options:
+        use24: false
+      readonly: false
+      required: false
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: lastVerified
+      table: socialServices
+      data_type: timestamp without time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: socialServices
+    field: tags
+    type: json
+    meta:
+      collection: socialServices
+      conditions: null
+      display: null
+      display_options: null
+      field: tags
+      group: null
+      hidden: false
+      interface: select-multiple-checkbox
+      note: null
+      options:
+        choices:
+          - text: Child Services
+            value: childServices
+          - text: Day Care Services
+            value: dayCareServices
+          - text: Disability Services
+            value: disabilityServices
+          - text: Domestic Abuse Services
+            value: domesticAbuseServices
+          - text: Educational Services
+            value: educationalServices
+          - text: Employment Services
+            value: employmentServices
+          - text: Family Services
+            value: familyServices
+          - text: Financial Services
+            value: financialServices
+          - text: Food Assistance
+            value: foodAssistance
+          - text: Health Services
+            value: healthServices
+          - text: Housing Services
+            value: housingServices
+          - text: Immigrants Services
+            value: immigrantsServices
+          - text: Legal Services
+            value: legalServices
+          - text: LGBTQ+ Friendly
+            value: lgbtq+Friendly
+          - text: Mental Health Services
+            value: mentalHealthServices
+          - text: Mutual Aid
+            value: mutualAid
+          - text: Pet Services
+            value: petServices
+          - text: Senior Services
+            value: seniorServices
+          - text: SNAP Services
+            value: snapServices
+          - text: Substance Use Programs
+            value: substanceUsePrograms
+          - text: Technology Services
+            value: technologyServices
+          - text: Veteran Services
+            value: veteranServices
+          - text: WIC Services
+            value: wicServices
+          - text: Womens Services
+            value: womensServices
+      readonly: false
+      required: false
+      sort: 13
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: tags
+      table: socialServices
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: templates
+    field: id
+    type: uuid
+    meta:
+      collection: templates
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: templates
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: templates
+    field: handle
+    type: string
+    meta:
+      collection: templates
+      conditions: null
+      display: null
+      display_options: null
+      field: handle
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: handle
+      table: templates
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: templates
+    field: subhandle
+    type: string
+    meta:
+      collection: templates
+      conditions: null
+      display: null
+      display_options: null
+      field: subhandle
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: subhandle
+      table: templates
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: templates
+    field: order
+    type: integer
+    meta:
+      collection: templates
+      conditions: null
+      display: null
+      display_options: null
+      field: order
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: order
+      table: templates
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: templates
+    field: template
+    type: text
+    meta:
+      collection: templates
+      conditions: null
+      display: null
+      display_options: null
+      field: template
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: markdown
+        lineWrapping: true
+      readonly: false
+      required: false
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: template
+      table: templates
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: updateCrewLogs
+    field: id
+    type: uuid
+    meta:
+      collection: updateCrewLogs
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: updateCrewLogs
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: updateCrewLogs
+    field: foodPantry
+    type: uuid
+    meta:
+      collection: updateCrewLogs
+      conditions: null
+      display: related-values
+      display_options:
+        template: '{{name}}'
+      field: foodPantry
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        enableCreate: false
+        template: '{{name}}'
+      readonly: false
+      required: false
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: foodPantry
+      table: updateCrewLogs
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: foodPantries
+      foreign_key_column: id
+  - collection: updateCrewLogs
+    field: socialService
+    type: uuid
+    meta:
+      collection: updateCrewLogs
+      conditions: null
+      display: null
+      display_options: null
+      field: socialService
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        enableCreate: false
+        enableLink: true
+        template: '{{name}}'
+      readonly: false
+      required: false
+      sort: 3
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: socialService
+      table: updateCrewLogs
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: socialServices
+      foreign_key_column: id
+  - collection: updateCrewLogs
+    field: retailFoodStore
+    type: uuid
+    meta:
+      collection: updateCrewLogs
+      conditions: null
+      display: null
+      display_options: null
+      field: retailFoodStore
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        enableCreate: false
+        enableLink: true
+        template: '{{name}}'
+      readonly: false
+      required: false
+      sort: 4
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: retailFoodStore
+      table: updateCrewLogs
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: retailFoodStores
+      foreign_key_column: id
+  - collection: updateCrewLogs
+    field: timestamp
+    type: dateTime
+    meta:
+      collection: updateCrewLogs
+      conditions:
+        - name: show when id is not null
+          options:
+            includeSeconds: false
+            use24: false
+          rule:
+            _and:
+              - id:
+                  _nnull: true
+      display: null
+      display_options: null
+      field: timestamp
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options:
+        use24: false
+      readonly: true
+      required: false
+      sort: 5
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: timestamp
+      table: updateCrewLogs
+      data_type: timestamp without time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: updateCrewLogs
+    field: user
+    type: uuid
+    meta:
+      collection: updateCrewLogs
+      conditions:
+        - name: hidden on create
+          options:
+            enableCreate: true
+            enableLink: false
+            enableSelect: true
+          rule:
+            _and:
+              - id:
+                  _null: true
+      display: null
+      display_options: null
+      field: user
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        enableCreate: false
+        template: '{{first_name}}{{last_name}}'
+      readonly: false
+      required: false
+      sort: 6
+      special:
+        - m2o
+        - user-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: user
+      table: updateCrewLogs
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: updateCrewLogs
+    field: notes
+    type: text
+    meta:
+      collection: updateCrewLogs
+      conditions: null
+      display: null
+      display_options: null
+      field: notes
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options:
+        softLength: 500
+        trim: true
+      readonly: false
+      required: false
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: notes
+      table: updateCrewLogs
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: updateCrewLogs
+    field: level
+    type: string
+    meta:
+      collection: updateCrewLogs
+      conditions: null
+      display: null
+      display_options: null
+      field: level
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: '#A2B5CD'
+            icon: add_call
+            text: Attempted
+            value: attempted
+          - color: '#2ECDA7'
+            icon: select_check_box
+            text: Verified
+            value: verified
+      readonly: false
+      required: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: level
+      table: updateCrewLogs
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: updateCrewLogs
+    field: flag
+    type: string
+    meta:
+      collection: updateCrewLogs
+      conditions: null
+      display: null
+      display_options: null
+      field: flag
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: No Followup Needed
+            value: noFollowupNeeded
+          - icon: exclamation
+            text: Followup Needed by Admin
+            value: followupNeeded
+          - icon: select_check_box
+            text: Followed Up by Admin
+            value: followedup
+      readonly: false
+      required: false
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: flag
+      table: updateCrewLogs
+      data_type: character varying
+      default_value: noFollowupNeeded
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+relations:
+  - collection: foodPantries_translations
+    field: foodPantries_id
+    related_collection: foodPantries
+    meta:
+      junction_field: languages_code
+      many_collection: foodPantries_translations
+      many_field: foodPantries_id
+      one_allowed_collections: null
+      one_collection: foodPantries
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: translations
+      sort_field: null
+    schema:
+      table: foodPantries_translations
+      column: foodPantries_id
+      foreign_key_table: foodPantries
+      foreign_key_column: id
+      constraint_name: foodpantries_translations_foodpantries_id_foreign
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: foodPantries_translations
+    field: languages_code
+    related_collection: languages
+    meta:
+      junction_field: foodPantries_id
+      many_collection: foodPantries_translations
+      many_field: languages_code
+      one_allowed_collections: null
+      one_collection: languages
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: foodPantries_translations
+      column: languages_code
+      foreign_key_table: languages
+      foreign_key_column: code
+      constraint_name: foodpantries_translations_languages_code_foreign
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: updateCrewLogs
+    field: foodPantry
+    related_collection: foodPantries
+    meta:
+      junction_field: null
+      many_collection: updateCrewLogs
+      many_field: foodPantry
+      one_allowed_collections: null
+      one_collection: foodPantries
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: updateCrewLogs
+      column: foodPantry
+      foreign_key_table: foodPantries
+      foreign_key_column: id
+      constraint_name: updatecrewlogs_foodpantry_foreign
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: updateCrewLogs
+    field: socialService
+    related_collection: socialServices
+    meta:
+      junction_field: null
+      many_collection: updateCrewLogs
+      many_field: socialService
+      one_allowed_collections: null
+      one_collection: socialServices
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: updateCrewLogs
+      column: socialService
+      foreign_key_table: socialServices
+      foreign_key_column: id
+      constraint_name: updatecrewlogs_socialservice_foreign
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: updateCrewLogs
+    field: retailFoodStore
+    related_collection: retailFoodStores
+    meta:
+      junction_field: null
+      many_collection: updateCrewLogs
+      many_field: retailFoodStore
+      one_allowed_collections: null
+      one_collection: retailFoodStores
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: updateCrewLogs
+      column: retailFoodStore
+      foreign_key_table: retailFoodStores
+      foreign_key_column: id
+      constraint_name: updatecrewlogs_retailfoodstore_foreign
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: updateCrewLogs
+    field: user
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: updateCrewLogs
+      many_field: user
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: updateCrewLogs
+      column: user
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: updatecrewlogs_user_foreign
+      on_update: NO ACTION
+      on_delete: SET NULL

--- a/docs/d7.md
+++ b/docs/d7.md
@@ -48,17 +48,26 @@ See [scripts/README.md](../scripts/README.md) for details.
 
 ## Directus Flows
 
-### Dump Food Pantries All Languages
+### Scheduled: Dump Food Pantries All Languages
 
 | | |
 |---|---|
-| **Trigger** | Manual / Webhook (POST) |
+| **Trigger** | Cron (every Sunday at midnight) |
 | **Flow ID** | `c912465d-74b5-4575-9a22-a87cf01b6756` |
 
-Reads all entries from the `languages` collection and triggers "Dump Open Food Pantries by Language" for each one, producing one JSON export per language.
+Reads all entries from the `languages` collection and triggers "Dump Open Food Pantries by Language" for each one, producing one JSON export per language. Runs automatically on a weekly schedule.
+
+### Manual: Dump Food Pantries All Languages
+
+| | |
+|---|---|
+| **Trigger** | Manual |
+| **Flow ID** | `75ae13e0-5dbb-4b24-9896-84fba30fff98` |
+
+Same behavior as the scheduled flow, but triggered on-demand from the Directus admin UI or via API:
 
 ```bash
-curl -X POST http://localhost:8055/flows/trigger/c912465d-74b5-4575-9a22-a87cf01b6756 \
+curl -X POST http://localhost:8055/flows/trigger/75ae13e0-5dbb-4b24-9896-84fba30fff98 \
   -H "Authorization: Bearer <static-token>"
 ```
 
@@ -86,8 +95,12 @@ Exports all food pantries with `status: "open"` for a given language:
 
 ### Version tracking
 
-Flows live in the database and are not tracked in git by default. Use the Directus schema snapshot to export them:
+Flows and schema live in the database. Export them for git tracking:
 
 ```bash
-docker exec d7_directus npx directus schema snapshot --yes /directus/uploads/snapshot.yaml
+yarn export:all      # schema snapshot + flows export
+yarn export:schema   # schema only → d7/snapshot.yaml
+yarn export:flows    # flows only → d7/flows.json
 ```
+
+Run before committing any changes to flows or the data model.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
         "backup:db:full": "node scripts/backup_d7_postgres.js --full",
         "backup:full": "node scripts/backup_full.js",
         "restore:full": "node scripts/restore_full.js",
-        "translate:foodPantries": "node scripts/translate_food_pantries.js"
+        "translate:foodPantries": "node scripts/translate_food_pantries.js",
+        "export:flows": "node scripts/export_flows.js",
+        "export:schema": "docker exec d7_directus npx directus schema snapshot --yes /directus/uploads/snapshot.yaml && docker cp d7_directus:/directus/uploads/snapshot.yaml ./d7/snapshot.yaml",
+        "export:all": "yarn export:schema && yarn export:flows"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.735.0",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -64,13 +64,34 @@ Translates the `name`, `notes`, and `hours` fields for all food pantries into th
 The script is idempotent. It skips translations that are already up to date. A translation is considered stale when the food pantry's `lastVerified` is newer than the translation's `lastUpdated`.
 
 ```bash
-yarn translate:foodPantries
+yarn translate:foodPantries           # only translate new/stale records
+yarn translate:foodPantries --force   # re-translate everything
 ```
 
 Requires:
 - Directus running with a static token configured
 - LibreTranslate running (default: `http://localhost:5000`)
 - Languages populated in the `languages` collection
+
+## Schema & Flow Export
+
+### `export_flows.js` — Export Directus Flows
+
+Exports all flows and their operations from Directus to `d7/flows.json` for version tracking.
+
+```bash
+yarn export:flows
+```
+
+### Schema Snapshot
+
+Exports the full Directus schema (collections, fields, relations) to `d7/snapshot.yaml`:
+
+```bash
+yarn export:schema
+```
+
+Both should be run before committing changes to flows or the data model.
 
 ## Environment Variables
 

--- a/scripts/export_flows.js
+++ b/scripts/export_flows.js
@@ -1,0 +1,41 @@
+const http = require('http');
+const path = require('path');
+const fs = require('fs');
+const dotenv = require('dotenv');
+
+dotenv.config({ path: path.join(__dirname, '../env/d7.env') });
+
+const DIRECTUS_URL = 'http://localhost:8055';
+const STATIC_TOKEN = process.env.D7_DIRECTUS_STATIC_TOKEN;
+
+if (!STATIC_TOKEN) {
+    console.error('Error: D7_DIRECTUS_STATIC_TOKEN is required in d7.env');
+    process.exit(1);
+}
+
+function fetch(url, headers) {
+    return new Promise((resolve, reject) => {
+        const req = http.request(url, { headers }, res => {
+            let data = '';
+            res.on('data', c => data += c);
+            res.on('end', () => resolve(JSON.parse(data)));
+        });
+        req.on('error', reject);
+        req.end();
+    });
+}
+
+async function main() {
+    const headers = { 'Authorization': `Bearer ${STATIC_TOKEN}` };
+
+    const result = await fetch(`${DIRECTUS_URL}/flows?fields=*,operations.*&limit=-1`, headers);
+
+    const outPath = path.join(__dirname, '../d7/flows.json');
+    fs.writeFileSync(outPath, JSON.stringify(result.data, null, 2) + '\n');
+    console.log(`Exported ${result.data.length} flows to ${outPath}`);
+}
+
+main().catch(err => {
+    console.error('Export failed:', err);
+    process.exit(1);
+});

--- a/scripts/translate_food_pantries.js
+++ b/scripts/translate_food_pantries.js
@@ -10,6 +10,7 @@ const DIRECTUS_URL = 'http://localhost:8055';
 const LIBRETRANSLATE_URL = process.env.LIBRETRANSLATE_URL || 'http://localhost:5000';
 const LIBRETRANSLATE_API_KEY = process.env.LIBRETRANSLATE_API_KEY || '';
 const BATCH_SIZE = 50;
+const FORCE = process.argv.includes('--force');
 
 const mdToHtml = new showdown.Converter();
 const htmlToMd = new TurndownService({ bulletListMarker: '-' });
@@ -84,7 +85,7 @@ async function getLanguages(headers) {
 }
 
 async function main() {
-    console.log('Starting food pantries translation...\n');
+    console.log(`Starting food pantries translation...${FORCE ? ' (FORCE mode — re-translating all)' : ''}\n`);
 
     const headers = { 'Authorization': `Bearer ${STATIC_TOKEN}`, 'Content-Type': 'application/json' };
 
@@ -119,7 +120,7 @@ async function main() {
                 for (const lang of langs) {
                     const existing = (pantry.translations || []).find(t => t.languages_code === lang);
 
-                    if (existing) {
+                    if (existing && !FORCE) {
                         // Skip if translation exists and is newer than lastVerified
                         const lastVerified = pantry.lastVerified ? new Date(pantry.lastVerified) : null;
                         const lastUpdated = existing.lastUpdated ? new Date(existing.lastUpdated) : null;


### PR DESCRIPTION
## Summary
- Adds `export_flows.js` script to export Directus flows to `d7/flows.json`
- Adds `yarn export:schema`, `export:flows`, `export:all` commands (replaces `schema:snapshot`)
- Adds `--force` flag to `translate_food_pantries.js` to re-translate all records
- Commits initial schema snapshot (`d7/snapshot.yaml`) and flows export (`d7/flows.json`)
- Updates `docs/d7.md` with scheduled/manual flow split and version tracking docs
- Updates `scripts/README.md` with export docs and `--force` usage

## Test plan
- [x] `yarn export:all` successfully exports schema and 8 flows
- [x] `yarn translate:foodPantries --force` re-translates existing records

🤖 Generated with [Claude Code](https://claude.com/claude-code)