### PR TITLE
Fix crash on whitespace-only notes during translation

### DIFF
--- a/d7TranslationWorker/src/worker.ts
+++ b/d7TranslationWorker/src/worker.ts
@@ -94,7 +94,7 @@ async function processJob(job: Job<JobPayload>): Promise<void> {
     job.updateProgress(25);
     job.log(`${getNow()} - translated name`);
 
-    const translatedNotes = notes ? await translateMarkdown(notes, language) : null;
+    const translatedNotes = notes?.trim() ? await translateMarkdown(notes, language) : null;
     job.updateProgress(50);
     job.log(`${getNow()} - translated notes`);
 

--- a/scripts/translate_food_pantries.js
+++ b/scripts/translate_food_pantries.js
@@ -135,7 +135,7 @@ async function main() {
             
                     // Translate fields
                     const translatedName = pantry.name ? await translate(pantry.name, lang) : null;
-                    const translatedNotes = pantry.notes ? await translateMarkdown(pantry.notes, lang) : null;
+                    const translatedNotes = pantry.notes?.trim() ? await translateMarkdown(pantry.notes, lang) : null;
                     const translatedHours = await translateHours(pantry.hours, lang);
 
                     const payload = {


### PR DESCRIPTION
## Summary
- Adds `.trim()` check before translating notes fields, preventing Turndown crash when notes contain only whitespace characters (`\t`, `\n`, etc.)
- Fix applied to both the bulk translation script and the real-time translation worker

## Test plan
- [x] Verified fix by re-translating the two affected records (Hollis Community Christian Center, Church of Christ the King Pantry)
- [x] Confirmed translations created successfully for all 3 languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)