### PR TITLE
Add flow import script and CLI args for translation

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
         "backup:db:full": "node scripts/backup_d7_postgres.js --full",
         "backup:full": "node scripts/backup_full.js",
         "restore:full": "node scripts/restore_full.js",
-        "translate:foodPantries": "node scripts/translate_food_pantries.js",
+        "translate:foodPantries": "node scripts/translate_food_pantries.js --target http://localhost:8055",
         "export:flows": "node scripts/export_flows.js",
+        "import:flows": "node scripts/import_flows.js",
         "export:schema": "docker exec d7_directus npx directus schema snapshot --yes /directus/uploads/snapshot.yaml && docker cp d7_directus:/directus/uploads/snapshot.yaml ./d7/snapshot.yaml",
         "export:all": "yarn export:schema && yarn export:flows"
     },

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -64,12 +64,22 @@ Translates the `name`, `notes`, and `hours` fields for all food pantries into th
 The script is idempotent. It skips translations that are already up to date. A translation is considered stale when the food pantry's `lastVerified` is newer than the translation's `lastUpdated`.
 
 ```bash
-yarn translate:foodPantries           # only translate new/stale records
-yarn translate:foodPantries --force   # re-translate everything
+# Local instance (token from d7.env)
+node scripts/translate_food_pantries.js --target http://localhost:8055
+node scripts/translate_food_pantries.js --target http://localhost:8055 --force
+
+# Remote instance
+node scripts/translate_food_pantries.js --target https://example.com --token <static-token>
+node scripts/translate_food_pantries.js --target https://example.com --token <static-token> --force
 ```
 
+| Flag | Description |
+|---|---|
+| `--target <url>` | **(required)** Directus instance URL |
+| `--token <token>` | Static token (defaults to `D7_DIRECTUS_STATIC_TOKEN` from `d7.env`) |
+| `--force` | Re-translate all records, ignoring `lastUpdated` |
+
 Requires:
-- Directus running with a static token configured
 - LibreTranslate running (default: `http://localhost:5000`)
 - Languages populated in the `languages` collection
 
@@ -91,7 +101,32 @@ Exports the full Directus schema (collections, fields, relations) to `d7/snapsho
 yarn export:schema
 ```
 
-Both should be run before committing changes to flows or the data model.
+### `import_flows.js` — Import Directus Flows
+
+Imports flows from `d7/flows.json` into a Directus instance. Skips flows that already exist (by ID or name). Creates operations and wires up the resolve/reject chains.
+
+```bash
+# Import to local (token from d7.env)
+node scripts/import_flows.js --target http://localhost:8055
+
+# Import to remote
+node scripts/import_flows.js --target https://example.com --token <static-token>
+
+# Dry run
+node scripts/import_flows.js --target https://example.com --token <static-token> --dry-run
+
+# Import specific flow by name
+node scripts/import_flows.js --target https://example.com --token <static-token> --flow "Dump Open"
+```
+
+| Flag | Description |
+|---|---|
+| `--target <url>` | Directus instance URL (defaults to `http://localhost:8055`) |
+| `--token <token>` | Static token (defaults to `D7_DIRECTUS_STATIC_TOKEN` from `d7.env`) |
+| `--flow <name>` | Only import flows matching this name (case-insensitive partial match) |
+| `--dry-run` | Preview what would be imported without making changes |
+
+Export and import should be run before and after committing changes to flows or the data model.
 
 ## Environment Variables
 

--- a/scripts/import_flows.js
+++ b/scripts/import_flows.js
@@ -1,0 +1,181 @@
+const https = require('https');
+const http = require('http');
+const path = require('path');
+const fs = require('fs');
+const dotenv = require('dotenv');
+
+// Usage: node scripts/import_flows.js [--target <url>] [--token <token>] [--flow <name>] [--dry-run]
+// Defaults to local Directus from d7.env
+
+dotenv.config({ path: path.join(__dirname, '../env/d7.env') });
+
+const args = process.argv.slice(2);
+function getArg(flag) {
+    const i = args.indexOf(flag);
+    return i >= 0 ? args[i + 1] : null;
+}
+
+const TARGET_URL = getArg('--target') || 'http://localhost:8055';
+const TOKEN = getArg('--token') || process.env.D7_DIRECTUS_STATIC_TOKEN;
+const FLOW_FILTER = getArg('--flow'); // optional: only import flows matching this name
+const DRY_RUN = args.includes('--dry-run');
+
+if (!TOKEN) {
+    console.error('Error: token is required (--token or D7_DIRECTUS_STATIC_TOKEN in d7.env)');
+    process.exit(1);
+}
+
+function request(url, method, body) {
+    return new Promise((resolve, reject) => {
+        const u = new URL(url);
+        const mod = u.protocol === 'https:' ? https : http;
+        const options = {
+            hostname: u.hostname,
+            port: u.port,
+            path: u.pathname + u.search,
+            method,
+            headers: {
+                'Authorization': `Bearer ${TOKEN}`,
+                'Content-Type': 'application/json',
+            },
+        };
+        const req = mod.request(options, res => {
+            let data = '';
+            res.on('data', c => data += c);
+            res.on('end', () => {
+                try {
+                    resolve({ status: res.statusCode, data: JSON.parse(data) });
+                } catch {
+                    resolve({ status: res.statusCode, data: data });
+                }
+            });
+        });
+        req.on('error', reject);
+        if (body) req.write(JSON.stringify(body));
+        req.end();
+    });
+}
+
+async function main() {
+    const flowsPath = path.join(__dirname, '../d7/flows.json');
+    const allFlows = JSON.parse(fs.readFileSync(flowsPath, 'utf8'));
+
+    // Get existing flows on target
+    const existing = await request(`${TARGET_URL}/flows?fields=id,name&limit=-1`, 'GET');
+    const existingIds = new Set(existing.data.data.map(f => f.id));
+    const existingNames = new Set(existing.data.data.map(f => f.name));
+
+    // Get existing operations on target
+    const existingOps = await request(`${TARGET_URL}/operations?fields=id&limit=-1`, 'GET');
+    const existingOpIds = new Set(existingOps.data.data.map(o => o.id));
+
+    const flows = FLOW_FILTER
+        ? allFlows.filter(f => f.name.toLowerCase().includes(FLOW_FILTER.toLowerCase()))
+        : allFlows;
+
+    if (flows.length === 0) {
+        console.log('No flows to import.');
+        return;
+    }
+
+    for (const flow of flows) {
+        const skip = existingIds.has(flow.id);
+        const nameExists = existingNames.has(flow.name);
+
+        if (skip) {
+            console.log(`SKIP (exists by ID): ${flow.name}`);
+            continue;
+        }
+        if (nameExists) {
+            console.log(`SKIP (exists by name): ${flow.name}`);
+            continue;
+        }
+
+        console.log(`\nImporting flow: ${flow.name} (${flow.trigger})`);
+
+        // Create the flow without linking the first operation yet
+        const flowPayload = {
+            id: flow.id,
+            name: flow.name,
+            icon: flow.icon,
+            color: flow.color,
+            description: flow.description,
+            status: flow.status,
+            trigger: flow.trigger,
+            accountability: flow.accountability,
+            options: flow.options,
+        };
+
+        if (DRY_RUN) {
+            console.log('  [dry-run] Would create flow:', flow.name);
+            console.log('  [dry-run] Would create', flow.operations.length, 'operations');
+            continue;
+        }
+
+        const flowRes = await request(`${TARGET_URL}/flows`, 'POST', flowPayload);
+        if (flowRes.status >= 400) {
+            console.error('  Error creating flow:', JSON.stringify(flowRes.data));
+            continue;
+        }
+        console.log('  Created flow');
+
+        // Create operations without resolve/reject links first
+        const ops = flow.operations || [];
+        for (const op of ops) {
+            if (existingOpIds.has(op.id)) {
+                console.log(`  SKIP operation (exists): ${op.name}`);
+                continue;
+            }
+
+            const opPayload = {
+                id: op.id,
+                name: op.name,
+                key: op.key,
+                type: op.type,
+                position_x: op.position_x,
+                position_y: op.position_y,
+                options: op.options,
+                flow: flow.id,
+            };
+
+            const opRes = await request(`${TARGET_URL}/operations`, 'POST', opPayload);
+            if (opRes.status >= 400) {
+                console.error(`  Error creating operation "${op.name}":`, JSON.stringify(opRes.data));
+            } else {
+                console.log(`  Created operation: ${op.name}`);
+            }
+        }
+
+        // Now wire up resolve/reject chains
+        for (const op of ops) {
+            if (existingOpIds.has(op.id)) continue;
+            if (op.resolve || op.reject) {
+                const patch = {};
+                if (op.resolve) patch.resolve = op.resolve;
+                if (op.reject) patch.reject = op.reject;
+
+                const patchRes = await request(`${TARGET_URL}/operations/${op.id}`, 'PATCH', patch);
+                if (patchRes.status >= 400) {
+                    console.error(`  Error linking "${op.name}":`, JSON.stringify(patchRes.data));
+                }
+            }
+        }
+
+        // Link the flow's first operation
+        if (flow.operation) {
+            const linkRes = await request(`${TARGET_URL}/flows/${flow.id}`, 'PATCH', { operation: flow.operation });
+            if (linkRes.status >= 400) {
+                console.error('  Error linking first operation:', JSON.stringify(linkRes.data));
+            } else {
+                console.log('  Linked operation chain');
+            }
+        }
+    }
+
+    console.log('\nDone.');
+}
+
+main().catch(err => {
+    console.error('Import failed:', err);
+    process.exit(1);
+});

--- a/scripts/translate_food_pantries.js
+++ b/scripts/translate_food_pantries.js
@@ -1,4 +1,5 @@
 const http = require('http');
+const https = require('https');
 const path = require('path');
 const dotenv = require('dotenv');
 const showdown = require('showdown');
@@ -6,18 +7,44 @@ const TurndownService = require('turndown');
 
 dotenv.config({ path: path.join(__dirname, '../env/d7.env') });
 
-const DIRECTUS_URL = 'http://localhost:8055';
+// CLI args
+const args = process.argv.slice(2);
+function getArg(flag) {
+    const i = args.indexOf(flag);
+    return i >= 0 ? args[i + 1] : null;
+}
+
+const DIRECTUS_URL = getArg('--target');
+const STATIC_TOKEN = getArg('--token') || process.env.D7_DIRECTUS_STATIC_TOKEN;
+const FORCE = args.includes('--force');
+
+if (!DIRECTUS_URL) {
+    console.log('Usage: node scripts/translate_food_pantries.js --target <directus-url> [options]\n');
+    console.log('Required:');
+    console.log('  --target <url>    Directus instance URL (e.g. http://localhost:8055)');
+    console.log('\nOptions:');
+    console.log('  --token <token>   Static token (defaults to D7_DIRECTUS_STATIC_TOKEN from d7.env)');
+    console.log('  --force           Re-translate all records, ignoring lastUpdated');
+    process.exit(1);
+}
+
+if (!STATIC_TOKEN) {
+    console.error('Error: token is required (--token or D7_DIRECTUS_STATIC_TOKEN in d7.env)');
+    process.exit(1);
+}
+
 const LIBRETRANSLATE_URL = process.env.LIBRETRANSLATE_URL || 'http://localhost:5000';
 const LIBRETRANSLATE_API_KEY = process.env.LIBRETRANSLATE_API_KEY || '';
 const BATCH_SIZE = 50;
-const FORCE = process.argv.includes('--force');
 
 const mdToHtml = new showdown.Converter();
 const htmlToMd = new TurndownService({ bulletListMarker: '-' });
 
 function fetch(url, opts = {}) {
     return new Promise((resolve, reject) => {
-        const req = http.request(url, {
+        const u = new URL(url);
+        const mod = u.protocol === 'https:' ? https : http;
+        const req = mod.request(url, {
             method: opts.method || 'GET',
             headers: opts.headers || {}
         }, res => {
@@ -35,12 +62,6 @@ function fetch(url, opts = {}) {
         if (opts.body) req.write(opts.body);
         req.end();
     });
-}
-
-const STATIC_TOKEN = process.env.D7_DIRECTUS_STATIC_TOKEN;
-if (!STATIC_TOKEN) {
-    console.error('Error: D7_DIRECTUS_STATIC_TOKEN is required in d7.env');
-    process.exit(1);
 }
 
 async function translate(text, targetLang) {


### PR DESCRIPTION
## Summary
- `translate_food_pantries.js` now requires `--target <url>` and optionally accepts `--token`, enabling use against both local and remote Directus instances (http and https)
- New `import_flows.js` script imports flows from `d7/flows.json` into any Directus instance, with `--dry-run`, `--flow` filtering, and skip-if-exists logic
- Updated `scripts/README.md` with new usage docs and `package.json` with `import:flows` script

## Test plan
- [x] Verified `translate_food_pantries.js` usage output with no args
- [x] Verified translation against local instance
- [x] Verified translation against live instance (https)
- [x] Verified `import_flows.js` dry-run against live
- [x] Verified `import_flows.js` successfully imported 3 flows to live

🤖 Generated with [Claude Code](https://claude.com/claude-code)