### PR TITLE
Fix d7 Redis internal port

### DIFF
--- a/yaml/d7.yaml
+++ b/yaml/d7.yaml
@@ -76,11 +76,11 @@ services:
       CACHE_ENABLED: "true"
       CACHE_STORE: "redis"
       REDIS_HOST: d7_redis
-      REDIS_PORT: ${D7_REDIS_PORT}
+      REDIS_PORT: 6379
       PUBLIC_URL: ${D7_DIRECTUS_PUBLIC_URL}
       SECRET: ${D7_DIRECTUS_SECRET}
       WEBSOCKETS_ENABLED: "true"
-      REDIS: "redis://d7_redis:${D7_REDIS_PORT}"
+      REDIS: "redis://d7_redis:6379"
     image: directus/directus:11.5.1
     networks:
       - frg-network


### PR DESCRIPTION
## Summary
- Use internal port `6379` for container-to-container Redis connections instead of the host-mapped `D7_REDIS_PORT` (6378)
- Fixes `ECONNREFUSED` on d7_directus startup

## Test plan
- [ ] `yarn start:d7:d` — Directus starts without Redis connection errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)