### PR TITLE
Add translation workflow diagram

### DIFF
--- a/docs/translation_workflow.drawio
+++ b/docs/translation_workflow.drawio
@@ -1,0 +1,97 @@
+<mxfile host="app.diagrams.net" agent="claude" version="24.7.17">
+  <diagram name="Architecture" id="arch">
+    <mxGraphModel dx="1400" dy="900" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1400" pageHeight="800" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+
+        <!-- Writers (left of Directus, stacked) -->
+        <mxCell id="scraper" value="&lt;b&gt;AI agent&lt;/b&gt;&lt;br&gt;&lt;i&gt;scraper&lt;/i&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#57534e;fontSize=13;" vertex="1" parent="1">
+          <mxGeometry x="60" y="170" width="140" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="editor" value="Editor" style="shape=umlActor;verticalLabelPosition=bottom;labelBackgroundColor=none;verticalAlign=top;html=1;fontSize=13;strokeColor=#78716c;fillColor=#78716c;" vertex="1" parent="1">
+          <mxGeometry x="105" y="290" width="40" height="60" as="geometry" />
+        </mxCell>
+
+        <!-- Directus (hub) -->
+        <mxCell id="directus" value="&lt;b&gt;Directus&lt;/b&gt;&lt;br&gt;&lt;i&gt;source of truth&lt;/i&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#57534e;fontSize=13;" vertex="1" parent="1">
+          <mxGeometry x="300" y="180" width="180" height="70" as="geometry" />
+        </mxCell>
+
+        <!-- Translation loop (horizontal, going right) -->
+        <mxCell id="queue" value="&lt;b&gt;BullMQ / Redis&lt;/b&gt;&lt;br&gt;&lt;i&gt;translation queue&lt;/i&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#57534e;fontSize=13;" vertex="1" parent="1">
+          <mxGeometry x="580" y="185" width="180" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="worker" value="&lt;b&gt;Translation worker&lt;/b&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#57534e;fontSize=13;" vertex="1" parent="1">
+          <mxGeometry x="860" y="185" width="180" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="libre" value="&lt;b&gt;LibreTranslate&lt;/b&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#57534e;fontSize=13;" vertex="1" parent="1">
+          <mxGeometry x="1140" y="185" width="180" height="60" as="geometry" />
+        </mxCell>
+
+        <!-- Publish row (horizontal, going right along the bottom) -->
+        <mxCell id="r2" value="&lt;b&gt;R2&lt;/b&gt;&lt;br&gt;&lt;i&gt;cdn&lt;/i&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#57534e;fontSize=13;" vertex="1" parent="1">
+          <mxGeometry x="330" y="500" width="140" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="chmap" value="&lt;b&gt;CH Map&lt;/b&gt;&lt;br&gt;&lt;i&gt;react frontend&lt;/i&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#57534e;fontSize=13;" vertex="1" parent="1">
+          <mxGeometry x="620" y="500" width="140" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="user" value="End user" style="shape=umlActor;verticalLabelPosition=bottom;labelBackgroundColor=none;verticalAlign=top;html=1;fontSize=13;strokeColor=#78716c;fillColor=#78716c;" vertex="1" parent="1">
+          <mxGeometry x="910" y="500" width="40" height="60" as="geometry" />
+        </mxCell>
+
+        <!-- Edges: writers → Directus (enter Directus LEFT edge) -->
+        <mxCell id="e1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=classic;strokeColor=#44403c;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.3;entryDx=0;entryDy=0;" edge="1" parent="1" source="scraper" target="directus">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <mxCell id="e2" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=classic;strokeColor=#44403c;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.7;entryDx=0;entryDy=0;" edge="1" parent="1" source="editor" target="directus">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Translation loop edges (horizontal chain) -->
+        <mxCell id="e3" value="on-upsert" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=classic;strokeColor=#44403c;fontStyle=2;fontSize=11;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="directus" target="queue">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <mxCell id="e4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=classic;strokeColor=#44403c;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="queue" target="worker">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <mxCell id="e5" value="translate" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;startArrow=classic;endArrow=classic;strokeColor=#44403c;fontStyle=2;fontSize=11;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="worker" target="libre">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Worker → Directus (loop back OVER the top, enters Directus TOP) -->
+        <mxCell id="e6" value="write translation" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=classic;strokeColor=#44403c;fontStyle=2;fontSize=11;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="worker" target="directus">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="950" y="90" />
+              <mxPoint x="390" y="90" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Directus → R2 (down-left, scheduled dumps) -->
+        <mxCell id="e7" value="scheduled json dumps" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=classic;strokeColor=#44403c;fontStyle=2;fontSize=11;exitX=0.25;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="directus" target="r2">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- CH Map → R2 (pulls) -->
+        <mxCell id="e8" value="pulls" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=classic;strokeColor=#44403c;fontStyle=2;fontSize=11;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="chmap" target="r2">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- End user → CH Map (views) -->
+        <mxCell id="e9" value="views" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=classic;strokeColor=#44403c;fontStyle=2;fontSize=11;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="user" target="chmap">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>


### PR DESCRIPTION
## Summary
- Adds `docs/translation_workflow.drawio` documenting the end-to-end translation flow
- Shows writers (AI scraper + editor) → Directus → BullMQ queue → worker ↔ LibreTranslate → back to Directus
- Also captures the publish path: Directus → scheduled JSON dumps → R2 → CH Map → end user

## Test plan
- [ ] Open `docs/translation_workflow.drawio` in draw.io / diagrams.net and confirm it renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)