### PR TITLE
Wire bullmqQueueJob extension to the MQ Redis

### DIFF
--- a/d7/directus/extensions/bullmqQueueJob/src/api.ts
+++ b/d7/directus/extensions/bullmqQueueJob/src/api.ts
@@ -11,8 +11,9 @@ export default defineOperationApi<Options>({
   id: 'operation-queue-bullmq-job',
   handler: async ({config}, {data, env}) => {
     const connection = new Redis({
-      host: env.REDIS_HOST,
-      port: env.REDIS_PORT
+      host: env.MQ_REDIS_HOST ?? '127.0.0.1',
+      port: Number(env.MQ_REDIS_PORT ?? 6379),
+      password: env.MQ_REDIS_PASSWORD || undefined,
     });
     const queue = new Queue(data.$last.queue, {connection});
     const job = await queue.add(data.$last.name, data.$last.payload);

--- a/env/d7.env.template
+++ b/env/d7.env.template
@@ -40,3 +40,8 @@ D7_DIRECTUS_STATIC_TOKEN=
 D7_HC_DIRECTUS_URL=
 D7_HC_POSTGRES_URL=
 D7_HC_INTERVAL=3600
+
+# BullMQ / message queue Redis (separate from Directus's own cache Redis)
+MQ_REDIS_HOST=mq_redis
+MQ_REDIS_PORT=6379
+MQ_REDIS_PASSWORD=

--- a/yaml/d7.yaml
+++ b/yaml/d7.yaml
@@ -77,6 +77,9 @@ services:
       CACHE_STORE: "redis"
       REDIS_HOST: d7_redis
       REDIS_PORT: 6379
+      MQ_REDIS_HOST: ${MQ_REDIS_HOST}
+      MQ_REDIS_PORT: ${MQ_REDIS_PORT}
+      MQ_REDIS_PASSWORD: ${MQ_REDIS_PASSWORD}
       PUBLIC_URL: ${D7_DIRECTUS_PUBLIC_URL}
       SECRET: ${D7_DIRECTUS_SECRET}
       WEBSOCKETS_ENABLED: "true"
@@ -141,4 +144,5 @@ volumes:
 
 networks:
   frg-network:
-    driver: bridge
+    name: frg-shared
+    external: true

--- a/yaml/mq.yaml
+++ b/yaml/mq.yaml
@@ -77,4 +77,5 @@ volumes:
 
 networks:
   frg-network:
-    driver: bridge
+    name: frg-shared
+    external: true


### PR DESCRIPTION
## Summary
- Fixes the `bullmqQueueJob` Directus operation extension to read `MQ_REDIS_HOST`/`MQ_REDIS_PORT`/`MQ_REDIS_PASSWORD` instead of colliding with Directus's own `REDIS_HOST`/`REDIS_PORT` (which point at the cache Redis).
- Adds those env vars to `env/d7.env.template` and pipes them into `d7_directus` in `yaml/d7.yaml`.
- Switches both compose stacks to an external network (`frg-shared`) so the Directus container can resolve `mq_redis` across compose projects.

## Deploy
Before `up`:
```
docker network create frg-shared
```
Set the new vars in `env/d7.env`. Rebuild the extension (`dist/` is gitignored):
```
cd d7/directus/extensions/bullmqQueueJob && yarn install && yarn build
```

## Test plan
- [ ] `docker network create frg-shared`
- [ ] Bring up d7 + mq stacks
- [ ] Trigger a `foodPantries` update (with the on-update flow active + condition op patched to a Run Script)
- [ ] Bull Board at `http://localhost:3000` shows waiting jobs in queue `d7 food pantry translation`
- [ ] `d7_redis` gets **no** `bull:*` keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)