### PR TITLE
Refresh d7 translation worker README

### DIFF
--- a/d7/translationWorker/README.md
+++ b/d7/translationWorker/README.md
@@ -20,23 +20,26 @@ yarn start
 ## How it works
 
 1. A food pantry is updated in Directus (name, notes, or hours)
-2. The "Queue Food Pantry Translation on Update" flow enqueues one job per language
+2. The `Queue Food Pantry Translation ▸ On Update` flow enqueues one job per non-English language
 3. This worker picks up each job and:
+   - Skips jobs whose target language is not supported by LibreTranslate (currently `ht`)
    - Translates `name` as plain text
    - Translates `notes` as markdown (via HTML round-trip)
    - Translates `hours` JSON (only the optional `notes` field in each entry)
 4. Writes the translation back to `foodPantries_translations` via the Directus API
+5. Pings `HEALTHCHECK_URL` on each successful completion (if set)
 
 ## Environment Variables
 
 | Variable | Description |
 |---|---|
 | `DIRECTUS_URL` | Directus instance URL |
-| `DIRECTUS_STATIC_TOKEN` | Static API token for Directus admin user |
+| `DIRECTUS_STATIC_TOKEN` | Static API token for a Directus user with write access to `foodPantries_translations` |
 | `LIBRETRANSLATE_URL` | LibreTranslate endpoint |
 | `LIBRETRANSLATE_API_KEY` | LibreTranslate API key (optional) |
-| `MQ_HOST` | Redis host |
-| `MQ_PORT` | Redis port |
+| `MQ_HOST` | Redis (BullMQ) host |
+| `MQ_PORT` | Redis (BullMQ) port |
+| `HEALTHCHECK_URL` | Optional healthchecks.io ping URL — hit on each successful job |
 
 ## Monitoring
 


### PR DESCRIPTION
## Summary
- Renames flow reference to `Queue Food Pantry Translation ▸ On Update`
- Documents the `ht` skip in the worker
- Adds `HEALTHCHECK_URL` env row
- Notes token needs write access to `foodPantries_translations`, not admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)