### PR TITLE
Docs audit: refresh d7, scripts, auth

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -32,7 +32,7 @@ See [this GitHub issue](https://github.com/keycloak/keycloak/issues/14258) for t
 Create a Google app with redirect URI:
 
 ```
-http://localhost:8080/realms/master/broker/google/endpoint
+http://localhost:8123/realms/master/broker/google/endpoint
 ```
 
 ### 3. Disable automatic user creation
@@ -69,8 +69,10 @@ Reference: [Keycloak docs — Creating Users](https://www.keycloak.org/docs/late
 
 ## Reference URLs
 
+Port comes from `AUTH_KEYCLOAK_HOSTNAME_PORT` in `env/auth.env` (default `8123`).
+
 | Resource | URL |
 |---|---|
-| Admin dashboard | http://localhost:8080/admin/ |
-| User dashboard | http://localhost:8080/realms/master/account/#/ |
-| Well-known config | http://localhost:8080/realms/master/.well-known/openid-configuration |
+| Admin dashboard | http://localhost:8123/admin/ |
+| User dashboard | http://localhost:8123/realms/master/account/#/ |
+| Well-known config | http://localhost:8123/realms/master/.well-known/openid-configuration |

--- a/docs/d7.md
+++ b/docs/d7.md
@@ -2,21 +2,32 @@
 
 ## Backups
 
-The `scripts/backup_d7_postgres.js` script requires the AWS CLI installed system-wide:
+The `scripts/backup_d7_postgres.js` script requires the AWS CLI installed system-wide. Install as appropriate for the host:
 
 ```bash
+# Ubuntu server
 sudo snap install aws-cli --classic
+
+# macOS
+brew install awscli
+```
+
+Then configure credentials once:
+
+```bash
 aws configure
 # enter the access and secret key
 ```
 
 To reduce file size, revisions are not backed up by default. Use `--full` to include them.
 
-Automate with a cron job:
+Automate with a cron job on the server:
 
 ```bash
 0 0 * * SUN cd /home/ubuntu/frg/scripts && /home/ubuntu/.nvm/versions/node/v18.20.5/bin/node backup_d7_postgres.js
 ```
+
+Backups upload to the AWS S3 bucket named in `BACKUP_BUCKET_NAME` — this is distinct from the Cloudflare R2 bucket used for published JSON feeds.
 
 See [scripts/README.md](../scripts/README.md) for full backup and restore documentation.
 
@@ -34,7 +45,18 @@ Food pantry data is translated using LibreTranslate. Translations are stored in 
 
 ### Languages
 
-Managed in the `languages` collection. Currently: `en`, `es`, `ko`, `id`. Adding a new language to this collection automatically includes it in translation scripts and export flows.
+Managed in the `languages` collection. Adding a new language row automatically includes it in translation scripts and export flows.
+
+**Local development** typically has a small subset (`en`, `es`, `ko`, `id`, `zh`). **Production** has the full target list.
+
+#### Aliasing to LibreTranslate
+
+LibreTranslate uses ISO 639 codes with script suffixes for CJK languages. To keep clean codes in Directus while still calling the underlying script, the worker translates certain codes on the way to LibreTranslate:
+
+| Directus code | LibreTranslate code | Notes |
+|---|---|---|
+| `zh` | `zh-Hans` | Simplified Chinese. Extend `LIBRETRANSLATE_LANGUAGE_ALIASES` in `worker.ts` for other pairings. |
+| `ht` | *(skipped)* | Haitian Creole not supported by LibreTranslate; worker completes the job as a no-op. |
 
 ### Running translations
 
@@ -48,57 +70,78 @@ See [scripts/README.md](../scripts/README.md) for details.
 
 ### Real-time translation
 
-When a food pantry's `name`, `notes`, or `hours` is updated in Directus, the "Queue Food Pantry Translation on Update" flow automatically enqueues a translation job per language via BullMQ. The `d7TranslationWorker` picks up these jobs and writes the translated data back to `foodPantries_translations`.
+When a food pantry's `name`, `notes`, or `hours` is updated in Directus, the `Queue Food Pantry Translation ▸ On Update` flow automatically enqueues a translation job per non-English language via BullMQ. The `d7TranslationWorker` picks up these jobs and writes the translated data back to `foodPantries_translations`.
 
 The flow only fires when source fields change — updates to translations (from the worker or the bulk script) do not re-trigger it.
 
 To run the worker:
 
 ```bash
-cd d7TranslationWorker
+cd d7/translationWorker
 yarn install && yarn build
 yarn start
 ```
 
-See [d7TranslationWorker/env.template](../d7TranslationWorker/env.template) for required configuration.
+See [d7/translationWorker/env.template](../d7/translationWorker/env.template) for required configuration. Point `DIRECTUS_STATIC_TOKEN` at `D7_TRANSLATION_WORKER_TOKEN` (a scoped service-user token) — not the admin token.
 
 ## Directus Flows
 
-### Scheduled: Dump Food Pantries All Languages
+Flow names use a `▸` separator to group related flows in the admin UI:
 
-| | |
-|---|---|
-| **Trigger** | Cron (every Sunday at midnight) |
-| **Flow ID** | `c912465d-74b5-4575-9a22-a87cf01b6756` |
-
-Reads all entries from the `languages` collection and triggers "Dump Open Food Pantries by Language" for each one, producing one JSON export per language. Runs automatically on a weekly schedule.
-
-### Manual: Dump Food Pantries All Languages
-
-| | |
-|---|---|
-| **Trigger** | Manual |
-| **Flow ID** | `75ae13e0-5dbb-4b24-9896-84fba30fff98` |
-
-Same behavior as the scheduled flow, but triggered on-demand from the Directus admin UI or via API:
-
-```bash
-curl -X POST http://localhost:8055/flows/trigger/75ae13e0-5dbb-4b24-9896-84fba30fff98 \
-  -H "Authorization: Bearer <static-token>"
+```
+Queue Food Pantry Translation ▸ On Update
+Queue Job                    ▸ Enqueue helper
+Dump Food Pantries All Languages ▸ Manual
+Dump Food Pantries All Languages ▸ Scheduled
+Dump Open Food Pantries by Language ▸ Worker
 ```
 
-### Queue Food Pantry Translation on Update
+### `Queue Food Pantry Translation ▸ On Update`
 
 | | |
 |---|---|
 | **Trigger** | Event (`items.update` on `foodPantries`) |
 | **Flow ID** | `58003834-ac8d-4159-965a-61ea96cf5ec2` |
 
-Fires when a food pantry is updated. Checks if `name`, `notes`, or `hours` changed, then enqueues a BullMQ job per non-English language on the `d7 food pantry translation` queue. The `d7TranslationWorker` processes these jobs.
+Fires when a food pantry is updated. A Run Script gates on whether `name`, `notes`, or `hours` was in the update payload (Directus's `Condition` op silently errors when a filtered key is missing from the delta — the Run Script handles the presence check correctly). If any of the three changed, the flow reads all non-English languages and enqueues one BullMQ job per language on the `d7 food pantry translation` queue. The `d7TranslationWorker` processes these jobs.
 
 **Note:** Disable this flow before running the bulk translation script (`yarn translate:foodPantries`) to avoid redundant jobs.
 
-### Dump Open Food Pantries by Language
+### `Queue Job ▸ Enqueue helper`
+
+| | |
+|---|---|
+| **Trigger** | Operation (called by other flows) |
+| **Flow ID** | `18e2267d-34d0-4e71-9686-c740b01bf571` |
+
+Thin wrapper around the `bullmqQueueJob` operation extension. Called from `Queue Food Pantry Translation ▸ On Update` (once per language) with `{queue, name, payload}`. The extension reads `MQ_REDIS_*` env vars — distinct from Directus's cache Redis (`REDIS_HOST`) — and enqueues on the specified queue.
+
+### `Dump Food Pantries All Languages ▸ Scheduled`
+
+| | |
+|---|---|
+| **Trigger** | Cron (every Sunday at midnight) |
+| **Flow ID** | `c912465d-74b5-4575-9a22-a87cf01b6756` |
+
+Reads all entries from the `languages` collection and triggers `Dump Open Food Pantries by Language ▸ Worker` for each one, producing one JSON dump per language.
+
+### `Dump Food Pantries All Languages ▸ Manual`
+
+| | |
+|---|---|
+| **Trigger** | Manual |
+| **Flow ID** | `75ae13e0-5dbb-4b24-9896-84fba30fff98` |
+
+Same behavior as the scheduled flow, triggered on-demand from the Directus admin UI or via API:
+
+```bash
+curl -X POST http://localhost:8055/flows/trigger/75ae13e0-5dbb-4b24-9896-84fba30fff98 \
+  -H "Authorization: Bearer <static-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"collection":"foodPantries","keys":[]}'
+```
+
+### `Dump Open Food Pantries by Language ▸ Worker`
 
 | | |
 |---|---|
@@ -107,18 +150,22 @@ Fires when a food pantry is updated. Checks if `name`, `notes`, or `hours` chang
 
 Exports all food pantries with `status: "open"` for a given language:
 
-1. **Read Data** — fetches all open food pantries with translations
-2. **Scrub Data** — whitelists fields, strips private phone numbers and emails, swaps in translated fields for the requested language
-3. **Save File** — saves as `foodPantriesOpen.{lang}.json` to Directus files
+1. **Read Data** — fetches all open food pantries with their translations
+2. **Scrub Data** — whitelists fields (drops `directus_files` refs, revisions, etc.), strips private phone numbers and email addresses, and merges the translated `name`/`notes`/`hours` for the requested language into each record
+3. **Build R2 Payload** — packages the scrubbed array as JSON with `Content-Type: application/json` and `Cache-Control: public, max-age=900`. Returns two payloads when the language is `en` (see below).
+4. **Upload to R2** — writes to Cloudflare R2 via the `uploadToR2` operation extension. Accepts either a single payload or an array of payloads.
 
-### Output files
+### Output files (R2)
 
-| File | Language |
+Every dump lands in the `cfam-public` R2 bucket under the `feeds/` prefix. Public read at `https://files.cfamhub.org/`.
+
+| Key | Public URL |
 |---|---|
-| `foodPantriesOpen.en.json` | English (source data, no translations applied) |
-| `foodPantriesOpen.es.json` | Spanish |
-| `foodPantriesOpen.ko.json` | Korean |
-| `foodPantriesOpen.id.json` | Indonesian |
+| `feeds/pantries.open.en.json` | `https://files.cfamhub.org/feeds/pantries.open.en.json` |
+| `feeds/pantries.open.<lang>.json` | one per non-English language |
+| `feeds/pantries.open.json` | mirror of the English file — served as the no-suffix fallback |
+
+The no-suffix mirror is written by the same worker run that produces `pantries.open.en.json`. When the Run Script sees `language === 'en'`, it returns an array of two payloads pointing at both keys.
 
 ### Version tracking
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -130,16 +130,56 @@ Export and import should be run before and after committing changes to flows or 
 
 ## Environment Variables
 
-All set in `env/d7.env`:
+All set in `env/d7.env`. See `env/d7.env.template` for the full annotated list.
+
+### Postgres
 
 | Variable | Description |
 |---|---|
 | `D7_POSTGRES_DB` | PostgreSQL database name |
 | `D7_POSTGRES_USER` | PostgreSQL user |
+
+### Directus tokens
+
+| Variable | Description |
+|---|---|
+| `D7_DIRECTUS_STATIC_TOKEN` | Static token for the Directus admin user. Used by the bulk translation script and other tooling. |
+| `D7_TRANSLATION_WORKER_TOKEN` | Scoped token for the `translation-worker` service user. Used by the `d7TranslationWorker` runtime — do not use for one-off scripts. |
+
+### Backups (AWS S3)
+
+| Variable | Description |
+|---|---|
 | `BACKUP_BUCKET_NAME` | S3 bucket for storing backups |
 | `BACKUP_REGION` | AWS region for the S3 bucket |
 | `D7_DIRECTUS_AWS_S3_KEY_ID` | AWS access key ID for S3 |
 | `D7_DIRECTUS_AWS_S3_ACCESS_KEY` | AWS secret access key for S3 |
-| `D7_DIRECTUS_STATIC_TOKEN` | Static API token for Directus admin user |
+
+### Translation
+
+| Variable | Description |
+|---|---|
 | `LIBRETRANSLATE_URL` | LibreTranslate endpoint (default: `http://localhost:5000`) |
 | `LIBRETRANSLATE_API_KEY` | LibreTranslate API key (optional, if auth is required) |
+
+### Message queue (BullMQ)
+
+Used by the `bullmqQueueJob` Directus operation to enqueue translation jobs.
+
+| Variable | Description |
+|---|---|
+| `MQ_REDIS_HOST` | Hostname of the queue Redis (default: `mq_redis` on the shared docker network) |
+| `MQ_REDIS_PORT` | Port (default: `6379`) |
+| `MQ_REDIS_PASSWORD` | Password if the queue Redis has `requirepass` set; empty otherwise |
+
+### Publish target (Cloudflare R2)
+
+Used by the `uploadToR2` Directus operation to write scheduled JSON dumps.
+
+| Variable | Description |
+|---|---|
+| `D7_DIRECTUS_R2_ENDPOINT` | R2 S3 endpoint (`https://<account_id>.r2.cloudflarestorage.com`) |
+| `D7_DIRECTUS_R2_ACCESS_KEY_ID` | R2 API token — access key ID |
+| `D7_DIRECTUS_R2_SECRET_ACCESS_KEY` | R2 API token — secret |
+| `D7_DIRECTUS_R2_BUCKET` | Bucket name (e.g. `cfam-public`) |
+| `D7_DIRECTUS_R2_PUBLIC_BASE_URL` | Public URL that CH Map fetches from (e.g. `https://files.cfamhub.org`) |


### PR DESCRIPTION
## Summary
Documentation audit + refresh across three files to match the current state of the translation and publish pipelines.

### `docs/auth.md`
- Reconcile port confusion (`8080` vs `8123`) — canonical is `8123` from `AUTH_KEYCLOAK_HOSTNAME_PORT`

### `scripts/README.md`
- Split env-var table by concern: Postgres, Directus tokens, Backups (AWS S3), Translation, Message queue, Publish target (R2)
- Add `D7_TRANSLATION_WORKER_TOKEN`, `MQ_REDIS_*`, `D7_DIRECTUS_R2_*`

### `docs/d7.md`
- Rename flows in-place with the `▸` separator (e.g. `Queue Food Pantry Translation ▸ On Update`)
- Add `Queue Job ▸ Enqueue helper` section describing the `MQ_REDIS_*` wiring
- Rewrite `Dump Open Food Pantries by Language ▸ Worker`: Save File replaced by the four-step R2 chain (Read → Scrub → Build R2 Payload → Upload to R2)
- New Output files table: `https://files.cfamhub.org/feeds/pantries.open.<lang>.json` + no-suffix `en` mirror
- Document `zh → zh-Hans` alias and `ht` skip in the worker
- Fix worker path (`d7TranslationWorker` → `d7/translationWorker`)
- Add macOS `brew install awscli` variant next to the Ubuntu `snap install`
- Call out that backups (AWS S3) and feeds (Cloudflare R2) live in separate buckets to avoid future confusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)