### PR TITLE
Env-parameterize published ports for prod hardening

### DIFF
--- a/docs/d7.md
+++ b/docs/d7.md
@@ -1,5 +1,21 @@
 # Directus (d7)
 
+## Prod hardening: restricting published ports
+
+By default the compose files publish `d7_postgres`, `mq_redis`, and `mq_bullboard` on all interfaces (`0.0.0.0`). On any host reachable from the public internet, that exposes unauthenticated (mq_redis, mq_bullboard) or minimally-authenticated (postgres) services and must be restricted.
+
+Each of the three port publishes accepts a full docker-compose port string via an env var override. The default keeps the existing all-interfaces binding.
+
+| variable | file | typical prod value |
+|---|---|---|
+| `D7_POSTGRES_PORT_PUBLISH` | `env/d7.env` | `127.0.0.1:5432:5432` |
+| `MQ_REDIS_PORT_PUBLISH` | `env/mq.env` | `100.94.146.100:6379:6379` (Tailscale IP) |
+| `MQ_BULLBOARD_PORT_PUBLISH` | `env/mq.env` | `100.94.146.100:3000:3000` |
+
+Nothing on the host itself connects to these services via `127.0.0.1` — Directus reaches `mq_redis` over the shared docker network by hostname — so the Tailscale-only binding is sufficient for the mq services.
+
+After setting the vars, `docker compose -p frg-d7 -f ./yaml/d7.yaml --env-file ./env/d7.env up -d` (and the equivalent for mq) picks up the new bindings on next recreate. Verify with `ss -tlnp | grep -E ':5432|:6379|:3000'`.
+
 ## Backups
 
 The `scripts/backup_d7_postgres.js` script requires the AWS CLI installed system-wide. Install as appropriate for the host:

--- a/env/d7.env.template
+++ b/env/d7.env.template
@@ -3,6 +3,12 @@ D7_POSTGRES_DB=abc123
 D7_POSTGRES_HOST=localhost
 D7_POSTGRES_PASSWORD=secret
 D7_POSTGRES_PORT=5432
+
+# Optional: full docker-compose port publish string for the postgres
+# container. Overrides the default `${D7_POSTGRES_PORT}:5432` (all
+# interfaces). Set on prod hosts to restrict binding, e.g.:
+#   D7_POSTGRES_PORT_PUBLISH=127.0.0.1:5432:5432
+D7_POSTGRES_PORT_PUBLISH=
 D7_POSTGRES_USER=user123
 
 D7_DIRECTUS_AWS_S3_ACCESS_KEY=abc123

--- a/env/mq.env.template
+++ b/env/mq.env.template
@@ -1,5 +1,13 @@
 MQ_BULLBOARD_PORT=3000
 MQ_REDIS_PORT=6379
+
+# Optional: full docker-compose port publish strings for the two
+# containers. Override the default `${PORT}:6379` / `${PORT}:3000` (all
+# interfaces). Set on prod hosts to restrict binding, e.g.:
+#   MQ_REDIS_PORT_PUBLISH=100.94.146.100:6379:6379   # Tailscale only
+#   MQ_BULLBOARD_PORT_PUBLISH=100.94.146.100:3000:3000
+MQ_REDIS_PORT_PUBLISH=
+MQ_BULLBOARD_PORT_PUBLISH=
 MQ_USER_LOGIN=user
 MQ_USER_PASSWORD=password
 

--- a/yaml/d7.yaml
+++ b/yaml/d7.yaml
@@ -27,7 +27,7 @@ services:
       - frg-network
     platform: linux/amd64
     ports:
-      - "${D7_POSTGRES_PORT}:5432"
+      - "${D7_POSTGRES_PORT_PUBLISH:-${D7_POSTGRES_PORT}:5432}"
     volumes:
       - ../data/d7_postgres/config:/db_config
       - ../data/d7_postgres/data:/var/lib/postgresql/data

--- a/yaml/mq.yaml
+++ b/yaml/mq.yaml
@@ -7,7 +7,7 @@ services:
     networks:
       - frg-network
     ports:
-      - "${MQ_REDIS_PORT}:6379"
+      - "${MQ_REDIS_PORT_PUBLISH:-${MQ_REDIS_PORT}:6379}"
     restart: always
     volumes:
       - redis_db_data:/data/mq_redis
@@ -27,7 +27,7 @@ services:
     networks:
       - frg-network
     ports:
-      - "${MQ_BULLBOARD_PORT}:3000"
+      - "${MQ_BULLBOARD_PORT_PUBLISH:-${MQ_BULLBOARD_PORT}:3000}"
     restart: always
 
   mq_healthcheck:


### PR DESCRIPTION
## Summary
- All three sensitive port publishes (`d7_postgres`, `mq_redis`, `mq_bullboard`) now accept a full docker-compose port string via env var override, falling back to the existing all-interfaces default
- Prod hosts can now restrict bindings entirely from `env/*.env` without carrying uncommitted yaml drift that gets silently lost on `git pull`
- Documented the new vars in `env/d7.env.template`, `env/mq.env.template`, and a new "Prod hardening" section at the top of `docs/d7.md`

## New env vars

| variable | file | typical prod value |
|---|---|---|
| `D7_POSTGRES_PORT_PUBLISH` | `env/d7.env` | `127.0.0.1:5432:5432` |
| `MQ_REDIS_PORT_PUBLISH` | `env/mq.env` | `100.94.146.100:6379:6379` |
| `MQ_BULLBOARD_PORT_PUBLISH` | `env/mq.env` | `100.94.146.100:3000:3000` |

Dev leaves them unset → identical to previous behavior. Nothing on the host itself connects to the mq services via 127.0.0.1 (Directus reaches `mq_redis` over the shared docker network by hostname), so Tailscale-only binding is sufficient for those two.

## Deploy plan for live
1. `git pull` on the live server
2. Append the three vars with concrete values to `env/d7.env` and `env/mq.env`
3. Drop the current uncommitted `yaml/*.yaml` overrides (`git restore --staged --worktree yaml/`)
4. `docker compose -p frg-d7 -f ./yaml/d7.yaml --env-file ./env/d7.env up -d` and same for mq
5. Verify `ss -tlnp | grep -E ':5432|:6379|:3000'` still shows loopback/Tailscale only

🤖 Generated with [Claude Code](https://claude.com/claude-code)