### PR TITLE
Add CLAUDE.md files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# FRG (Food Resource Guide)
+
+Infrastructure project for Share Meals / Center for Food as Medicine. Manages Directus CMS, translation pipelines, and data exports via Docker Compose.
+
+## Project layout
+
+- `yaml/` — Docker Compose files (d7, mq, auth, i18n)
+- `env/` — Environment files (gitignored `*.env`, tracked `*.env.template`)
+- `d7/` — Directus config, extensions, translation worker, flows, schema snapshot
+- `scripts/` — CLI tools (backup, restore, translate, import/export)
+- `docs/` — Architecture and operational docs
+
+## Conventions
+
+- **Docker Compose only.** Do not create or modify Dockerfiles. Use mounted volumes for extensions and customizations.
+- **Project names.** All compose commands use `-p frg-<stack>` (e.g. `frg-d7`, `frg-mq`, `frg-auth`, `frg-i18n`).
+- **Env files.** Each stack has `env/<stack>.env` (secrets, gitignored) and `env/<stack>.env.template` (tracked). Always update the template when adding new env vars.
+- **Convenience scripts.** `yarn start:<stack>` / `yarn start:<stack>:d` for foreground/detached. See `package.json`.
+- **Shipping changes.** "Ship" means: create branch, commit, push, open PR, merge, return to main, delete local branch, prune remotes.
+
+## Service groups
+
+| Stack | Compose file | Services |
+|---|---|---|
+| d7 | `yaml/d7.yaml` | Directus, Postgres, Redis (cache), healthcheck |
+| mq | `yaml/mq.yaml` | Redis (queues), Bull Board, healthcheck |
+| auth | `yaml/auth.yaml` | Keycloak, Postgres |
+| i18n | `yaml/i18n.yaml` | LibreTranslate |
+
+d7 Redis (`d7_redis`) is for Directus caching. MQ Redis (`mq_redis`) is for BullMQ job queues. They are separate installations.
+
+## Flows and schema
+
+Directus flows and schema are stored in the database. Export before committing changes:
+
+```bash
+yarn export:all      # schema + flows
+yarn export:flows    # flows only -> d7/flows.json
+yarn export:schema   # schema only -> d7/snapshot.yaml
+```

--- a/d7/translationWorker/CLAUDE.md
+++ b/d7/translationWorker/CLAUDE.md
@@ -1,0 +1,30 @@
+# Translation Worker
+
+BullMQ consumer that translates food pantry fields via LibreTranslate and writes results back to Directus.
+
+## How it works
+
+1. Listens on the `"d7 food pantry translation"` Redis queue (MQ Redis, not d7 cache Redis)
+2. Receives jobs with `{pantryId, language, name, notes, hours}`
+3. Translates each field via LibreTranslate (`name` as plain text, `notes` as markdown-to-HTML roundtrip, `hours[].notes` as plain text)
+4. Creates or updates the translation in Directus's `foodPantries_translations` junction table
+
+## Job producer
+
+Jobs are enqueued by Directus Flow `58003834-ac8d-4159-965a-61ea96cf5ec2` ("Queue Food Pantry Translation on Update"). It fires on `items.update` to `foodPantries` when `name`, `notes`, or `hours` changes, and creates one job per non-English language. The flow is currently **inactive**.
+
+The flow calls the `Queue Job` helper flow (`18e2267d`), which uses the `bullmqQueueJob` Directus extension to push to MQ Redis.
+
+## Build and run
+
+```bash
+yarn install && yarn build
+yarn start
+```
+
+Requires env vars from `.env` (see `env.template`). Connects to MQ Redis (`MQ_HOST`/`MQ_PORT`), Directus (`DIRECTUS_URL`/`DIRECTUS_STATIC_TOKEN`), and LibreTranslate (`LIBRETRANSLATE_URL`).
+
+## Related
+
+- `scripts/translate_food_pantries.js` — batch script that translates all pantries directly (no queue). Disable the Directus flow before running to avoid redundant jobs.
+- `docs/d7.md` — full translation workflow docs including language aliasing.


### PR DESCRIPTION
## Summary
- Add root `CLAUDE.md` with project layout, conventions, and service group map
- Add `d7/translationWorker/CLAUDE.md` with worker mechanics and job producer context

## Test plan
- [ ] N/A — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)