### PR TITLE
Use restart: unless-stopped across compose files

### DIFF
--- a/yaml/d7.yaml
+++ b/yaml/d7.yaml
@@ -6,7 +6,7 @@ services:
       - frg-network
     ports:
       - "${D7_REDIS_PORT}:6379"
-    restart: always
+    restart: unless-stopped
     volumes:
       - d7_redis_data:/data
 
@@ -28,6 +28,7 @@ services:
     platform: linux/amd64
     ports:
       - "${D7_POSTGRES_PORT_PUBLISH:-${D7_POSTGRES_PORT}:5432}"
+    restart: unless-stopped
     volumes:
       - ../data/d7_postgres/config:/db_config
       - ../data/d7_postgres/data:/var/lib/postgresql/data
@@ -94,6 +95,7 @@ services:
       - frg-network
     ports:
       - "${D7_DIRECTUS_PORT}:8055"
+    restart: unless-stopped
     volumes:
       - ../d7/directus/uploads:/directus/uploads
       - ../d7/directus/extensions:/directus/extensions
@@ -141,7 +143,7 @@ services:
         done
     networks:
       - frg-network
-    restart: always
+    restart: unless-stopped
 
 volumes:
   d7_redis_data:

--- a/yaml/mq.yaml
+++ b/yaml/mq.yaml
@@ -8,7 +8,7 @@ services:
       - frg-network
     ports:
       - "${MQ_REDIS_PORT_PUBLISH:-${MQ_REDIS_PORT}:6379}"
-    restart: always
+    restart: unless-stopped
     volumes:
       - redis_db_data:/data/mq_redis
     
@@ -28,7 +28,7 @@ services:
       - frg-network
     ports:
       - "${MQ_BULLBOARD_PORT_PUBLISH:-${MQ_BULLBOARD_PORT}:3000}"
-    restart: always
+    restart: unless-stopped
 
   mq_healthcheck:
     container_name: mq_healthcheck
@@ -69,7 +69,7 @@ services:
         done
     networks:
       - frg-network
-    restart: always
+    restart: unless-stopped
 
 volumes:
   redis_db_data:


### PR DESCRIPTION
Switches all Docker Compose services to `restart: unless-stopped`.

- `yaml/d7.yaml` — `d7_redis` and `d7_healthcheck` changed from `always`; `d7_postgres` and `d7_directus` had **no** restart policy and now get `unless-stopped`.
- `yaml/mq.yaml` — `mq_redis`, `mq_bullboard`, `mq_healthcheck` changed from `always`.
- `yaml/auth.yaml`, `yaml/i18n.yaml` — already `unless-stopped`, untouched.

`unless-stopped` differs from `always` in that a container stopped by hand stays stopped when the Docker daemon restarts.

All four files validated with `docker compose config -q`.

Note: the policy only applies once containers are recreated (`docker compose -p frg-<stack> up -d`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)