### PR TITLE
Empty the LibreTranslate language alias map

### DIFF
--- a/d7/translationWorker/src/worker.ts
+++ b/d7/translationWorker/src/worker.ts
@@ -12,12 +12,13 @@ const LIBRETRANSLATE_URL = process.env.LIBRETRANSLATE_URL!;
 const LIBRETRANSLATE_API_KEY = process.env.LIBRETRANSLATE_API_KEY || '';
 const HEALTHCHECK_URL = process.env.HEALTHCHECK_URL || '';
 
+// Languages LibreTranslate cannot translate — worker no-ops the job.
+// TODO: revisit `ht` (Haitian Creole) if we plug in a second MT provider.
 const UNSUPPORTED_LANGUAGES = new Set(['ht']);
 
-// Directus stores clean language codes; LibreTranslate needs script-specific codes.
-const LIBRETRANSLATE_LANGUAGE_ALIASES = new Map<string, string>([
-    ['zh', 'zh-Hans'],
-]);
+// Reserved for cases where Directus's code and LibreTranslate's code diverge.
+// Currently empty — Directus stores `zh-Hans` / `zh-Hant` directly.
+const LIBRETRANSLATE_LANGUAGE_ALIASES = new Map<string, string>();
 
 const mdToHtml = new Showdown.Converter();
 const htmlToMd = new TurndownService({ bulletListMarker: '-' });


### PR DESCRIPTION
The alias map translated Directus language codes into LibreTranslate's script-specific codes, with a single `zh` -> `zh-Hans` entry.

Verified against the live `languages` table: codes are stored as `ar, bn, en, es, fr, ko, pl, ru, ur, zh-Hans` — there is no bare `zh` row, so the alias never matched. The map is now empty and documented as reserved for future divergence; both call sites already fall back with `?? targetLang`, so behavior is unchanged.

Also adds a comment explaining why `ht` (Haitian Creole) is in `UNSUPPORTED_LANGUAGES`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)