### PR TITLE
Bind LibreTranslate to container port 5000 regardless of I18N_LT_PORT

### DIFF
--- a/yaml/i18n.yaml
+++ b/yaml/i18n.yaml
@@ -3,14 +3,16 @@ services:
     container_name: i18n_libretranslate
     image: libretranslate/libretranslate:latest
     restart: unless-stopped
+    # I18N_LT_PORT is the host-side port only; LibreTranslate always listens on
+    # 5000 inside the container.
     ports:
       - "${I18N_LT_PORT}:5000"
     expose:
-      - ${I18N_LT_PORT}
+      - 5000
     environment:
       ARGOS_DEBUG: ${I18N_LT_ARGOS_DEBUG}
       LT_DEBUG: ${I18N_LT_DEBUG}
-      LT_PORT: ${I18N_LT_PORT}
+      LT_PORT: 5000
       LT_LOAD_ONLY: ${I18N_LT_LOAD_ONLY}
       LT_DISABLE_WEB_UI: ${I18N_LT_DISABLE_WEB_UI}
       LT_METRICS: ${I18N_LT_METRICS}


### PR DESCRIPTION
`I18N_LT_PORT` was driving both sides of the port mapping in `yaml/i18n.yaml`:

```yaml
ports:
  - "${I18N_LT_PORT}:5000"   # host port : container port
environment:
  LT_PORT: ${I18N_LT_PORT}    # port the LibreTranslate process binds to
```

The publish always targets container port **5000**, while `LT_PORT` sets the port the process binds to inside the container. Both read the same variable, so they only agreed while `I18N_LT_PORT` was itself `5000`.

Set it to anything else and the publish becomes `host:<port> -> container 5000` while the process binds `<port>`. Nothing listens on 5000, and every request to the host port is refused.

Latent until now — the variable exists to be changed, and `env/i18n.env` is gitignored, so each machine and deploy sets its own value. It surfaced while shifting local ports to avoid a clash with another Directus stack.

## Fix

Hardcode `LT_PORT` and `expose` to `5000` so `I18N_LT_PORT` only sets the host side of the mapping. This matches the pattern already used elsewhere in the repo — `d7.yaml` writes `"${D7_DIRECTUS_PORT}:8055"` and `mq.yaml` writes `"${MQ_BULLBOARD_PORT}:3000"`, both keeping the container side fixed.

## Verification

`docker compose -f yaml/i18n.yaml --env-file env/i18n.env config` resolves to `host 4995 -> container 5000` with `LT_PORT: "5000"`, on a non-default `I18N_LT_PORT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)