### PR TITLE
Fix auth port mapping and password var, document remaining flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ data/*
 !data/d7_directus/**/*
 node_modules
 d7/directus/uploads/
+
+# Local Claude Code settings — may contain tokens/credentials
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Directus admin lives at `http://localhost:8055`. Bull Board at `http://localhost
 
 | Doc | Covers |
 |---|---|
-| [docs/d7.md](docs/d7.md) | Directus specifics — backups, translations, all five flows, R2 output layout |
+| [docs/d7.md](docs/d7.md) | Directus specifics — backups, translations, all nine flows, R2 output layout |
 | [docs/auth.md](docs/auth.md) | Keycloak setup (Google IDP, no self-signup) |
 | [scripts/README.md](scripts/README.md) | CLI tooling: backups, bulk translation, flow import/export, and the full env-var reference |
 | [d7/translationWorker/README.md](d7/translationWorker/README.md) | The BullMQ worker itself |

--- a/d7/directus/extensions/file-by-filename/package.json
+++ b/d7/directus/extensions/file-by-filename/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "file-by-filename",
-	"description": "Please enter a description for your extension",
+	"description": "directus endpoint to look up a file by its filename and redirect to its asset URL",
 	"icon": "extension",
 	"version": "1.0.0",
 	"keywords": [

--- a/d7/directus/extensions/saveFile/package.json
+++ b/d7/directus/extensions/saveFile/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "saveFile",
-	"description": "Please enter a description for your extension",
+	"description": "directus operation to save the previous step's output into the file library, replacing any file of the same name",
 	"icon": "extension",
 	"version": "1.0.0",
 	"keywords": [

--- a/docs/d7.md
+++ b/docs/d7.md
@@ -63,16 +63,15 @@ Food pantry data is translated using LibreTranslate. Translations are stored in 
 
 Managed in the `languages` collection. Adding a new language row automatically includes it in translation scripts and export flows.
 
-**Local development** typically has a small subset (`en`, `es`, `ko`, `id`, `zh`). **Production** has the full target list.
+**Local development** usually carries a subset of the production list. Check the collection rather than assuming — `GET /items/languages`.
 
 #### Aliasing to LibreTranslate
 
-LibreTranslate uses ISO 639 codes with script suffixes for CJK languages. To keep clean codes in Directus while still calling the underlying script, the worker translates certain codes on the way to LibreTranslate:
+Directus stores the same codes LibreTranslate expects, script suffixes included (`zh-Hans` rather than a bare `zh`), so no aliasing is in effect today. `LIBRETRANSLATE_LANGUAGE_ALIASES` in `worker.ts` is an empty map kept for the case where the two ever diverge; add a `Directus code → LibreTranslate code` pair there if that happens.
 
-| Directus code | LibreTranslate code | Notes |
-|---|---|---|
-| `zh` | `zh-Hans` | Simplified Chinese. Extend `LIBRETRANSLATE_LANGUAGE_ALIASES` in `worker.ts` for other pairings. |
-| `ht` | *(skipped)* | Haitian Creole not supported by LibreTranslate; worker completes the job as a no-op. |
+| Directus code | Handling |
+|---|---|
+| `ht` | *Skipped.* Haitian Creole is not supported by LibreTranslate; the worker completes the job as a no-op. See `UNSUPPORTED_LANGUAGES` in `worker.ts`. |
 
 ### Running translations
 
@@ -102,7 +101,7 @@ See [d7/translationWorker/env.template](../d7/translationWorker/env.template) fo
 
 ## Directus Flows
 
-Flow names use a `▸` separator to group related flows in the admin UI:
+There are nine flows. The newer ones use a `▸` separator to group related flows in the admin UI; the community-guide and verification flows predate that convention and are named plainly.
 
 ```
 Queue Food Pantry Translation ▸ On Update
@@ -110,7 +109,13 @@ Queue Job                    ▸ Enqueue helper
 Dump Food Pantries All Languages ▸ Manual
 Dump Food Pantries All Languages ▸ Scheduled
 Dump Open Food Pantries by Language ▸ Worker
+Sync Last Attempted Verify
+Manual Build Communities
+Build Communities
+Build Community
 ```
+
+The five `▸` flows are the translate and pantry-feed pipelines, documented first. The remaining four cover update-crew verification stamps and the community guide build, documented under [Community guide flows](#community-guide-flows) and [Verification flows](#verification-flows).
 
 ### `Queue Food Pantry Translation ▸ On Update`
 
@@ -183,7 +188,65 @@ Every dump lands in the `cfam-public` R2 bucket under the `feeds/` prefix. Publi
 
 The no-suffix mirror is written by the same worker run that produces `pantries.open.en.json`. When the Run Script sees `language === 'en'`, it returns an array of two payloads pointing at both keys.
 
-### Version tracking
+## Community guide flows
+
+A second publish pipeline, independent of the pantry JSON feeds. It renders a per-community HTML guide from a Pug template and uploads it to **AWS S3** (not R2).
+
+### `Build Community`
+
+| | |
+|---|---|
+| **Trigger** | Operation (called by parent flow) |
+| **Flow ID** | `963537d8-2d0e-4c00-b7ce-82cc1d4c5432` |
+
+Takes one community and builds its guide:
+
+1. **Read** `farmersMarkets`, `foodPantries`, `retailFoodStores`, and `socialServices`, each filtered by `geolocation._intersects_bbox` against the community's `geometry` — so a community's boundary selects its content
+2. **Read** the `templates` rows with `handle: "FPC Web"`, sorted by `order`
+3. **Transform** the four result sets plus the community into a single payload
+4. **Render** via the `transformPug` operation extension
+5. **Generate a table of contents** by regex-scanning the rendered HTML for `<section id>` / heading pairs
+6. **Upload to S3** via the `uploadToS3` operation extension
+
+It also has a disabled branch that would enqueue translation jobs on an `fpc web i18n` queue via `Queue Job ▸ Enqueue helper`. The Run Script gates it behind a literal `&& false` with a `TODO: temporarily disable translations`, so no community-guide translation happens today.
+
+### `Build Communities`
+
+| | |
+|---|---|
+| **Trigger** | Manual (on `communities`, no selection required) |
+| **Flow ID** | `5816f3ca-53c1-4dfb-8d88-00c838fc19e9` |
+
+Reads every community sorted by name and fans out to `Build Community` for each — the same fan-out shape as `Dump Food Pantries All Languages`.
+
+### `Manual Build Communities`
+
+| | |
+|---|---|
+| **Trigger** | Manual, `requireConfirmation: true` |
+| **Flow ID** | `e3192bde-f031-45be-9895-f422ebf646f3` |
+
+A single trigger operation pointing at `Build Communities`. It exists only to put a confirmation dialog in front of a full rebuild.
+
+## Verification flows
+
+### `Sync Last Attempted Verify`
+
+| | |
+|---|---|
+| **Trigger** | Event (`items.create` on `updateCrewLogs`) |
+| **Flow ID** | `384eeae1-3ea8-4034-bb1f-91f7d3209ec7` |
+
+Stamps verification dates on a food pantry when the update crew logs a call. It generates an ISO timestamp, checks the log actually references a pantry, then writes to `foodPantries`:
+
+| Log `level` | Field written |
+|---|---|
+| `verified` | `lastVerified` |
+| anything else | `lastAttemptedVerify` |
+
+**This flow feeds the translation staleness check.** A translation is considered stale when a pantry's `lastVerified` is newer than the translation's `lastUpdated`, so a crew member marking a call `verified` is what makes `yarn translate:foodPantries` pick that pantry up again.
+
+## Version tracking
 
 Flows and schema live in the database. Export them for git tracking:
 

--- a/scripts/export_flows.js
+++ b/scripts/export_flows.js
@@ -1,11 +1,21 @@
+const https = require('https');
 const http = require('http');
 const path = require('path');
 const fs = require('fs');
 const dotenv = require('dotenv');
 
+// Usage: node scripts/export_flows.js [--target <url>]
+// Defaults to D7_DIRECTUS_PUBLIC_URL from d7.env
+
 dotenv.config({ path: path.join(__dirname, '../env/d7.env') });
 
-const DIRECTUS_URL = 'http://localhost:8055';
+const args = process.argv.slice(2);
+function getArg(flag) {
+    const i = args.indexOf(flag);
+    return i >= 0 ? args[i + 1] : null;
+}
+
+const DIRECTUS_URL = getArg('--target') || process.env.D7_DIRECTUS_PUBLIC_URL || 'http://localhost:8055';
 const STATIC_TOKEN = process.env.D7_DIRECTUS_STATIC_TOKEN;
 
 if (!STATIC_TOKEN) {
@@ -15,7 +25,8 @@ if (!STATIC_TOKEN) {
 
 function fetch(url, headers) {
     return new Promise((resolve, reject) => {
-        const req = http.request(url, { headers }, res => {
+        const mod = new URL(url).protocol === 'https:' ? https : http;
+        const req = mod.request(url, { headers }, res => {
             let data = '';
             res.on('data', c => data += c);
             res.on('end', () => resolve(JSON.parse(data)));

--- a/yaml/auth.yaml
+++ b/yaml/auth.yaml
@@ -11,7 +11,7 @@ services:
     networks:
       - frg-network
     ports:
-      - "${AUTH_POSTGRES_PORT}:${AUTH_POSTGRES_PORT}"
+      - "${AUTH_POSTGRES_PORT}:5432"
     restart: unless-stopped
     volumes:
       - ../data/auth_postgres:/var/lib/postgresql/data
@@ -38,7 +38,7 @@ services:
       DB_ADDR: auth_postgres
       DB_DATABASE: ${AUTH_POSTGRES_DB}
       DB_USER: ${AUTH_POSTGRES_USER}
-      DB_PASSWORD: ${AUTH_POSTGRES_PASS}
+      DB_PASSWORD: ${AUTH_POSTGRES_PASSWORD}
       KEYCLOAK_ADMIN: ${AUTH_KEYCLOAK_ADMIN}
       KEYCLOAK_ADMIN_PASSWORD: ${AUTH_KEYCLOAK_ADMIN_PASSWORD}
       KEYCLOAK_HOSTNAME: localhost


### PR DESCRIPTION
Two latent `auth` stack bugs, plus documentation that had drifted from the database.

## `yaml/auth.yaml`

**Dead port publish.** The mapping was `"${AUTH_POSTGRES_PORT}:${AUTH_POSTGRES_PORT}"` — host port to a container port of the same number. Postgres always listens on `5432` inside the container, so the published port pointed at nothing regardless of the value. Now `"${AUTH_POSTGRES_PORT}:5432"`.

Verified by starting the container: `127.0.0.1:5426 - accepting connections`.

**Undefined password variable.** `DB_PASSWORD: ${AUTH_POSTGRES_PASS}` — that name is defined nowhere. The variable is `AUTH_POSTGRES_PASSWORD`, used correctly two dozen lines up for `POSTGRES_PASSWORD`. Compose substituted an empty string and warned on every start:

```
warning: The "AUTH_POSTGRES_PASS" variable is not set. Defaulting to a blank string.
```

Scope: Keycloak still runs `start-dev` against embedded H2 using the legacy `DB_VENDOR`/`DB_ADDR` names, so `DB_PASSWORD` is not read today. This corrects a config path that is not yet live; it does not change current behavior. Migrating to `KC_DB_*` is separate and carries a data question, since anything currently in H2 lives inside the container.

All four stacks now resolve with zero unset-variable warnings.

## Documentation

**Four flows were undocumented.** `docs/d7.md` described five; the database has nine. Added `Build Community`, `Build Communities`, `Manual Build Communities`, and `Sync Last Attempted Verify` — the community-guide pipeline (Pug → S3, a separate path from the pantry JSON feeds) and the update-crew verification stamps. All nine are now covered by flow ID.

Worth surfacing: `Sync Last Attempted Verify` writes `lastVerified`, which is exactly what the translation staleness check reads. A crew member marking a call `verified` is what makes `yarn translate:foodPantries` pick that pantry up again. That link wasn't recorded anywhere.

Two things documented as-is rather than papered over: `Build Community`'s transform references `{{ get_community_fridges }}` but no such operation exists in that flow, and its translation branch is gated behind a literal `&& false`.

**Stale alias table.** `docs/d7.md` still described `zh` → `zh-Hans` aliasing. The `languages` collection stores `zh-Hans` directly and `LIBRETRANSLATE_LANGUAGE_ALIASES` has been empty since #48. Only the `ht` skip remains. Also dropped the "local has `en, es, ko, id, zh`" claim — actual local is ten languages and contains no `id`.

**README** said "all five flows".

## `scripts/export_flows.js`

Hardcoded `http://localhost:8055` with no flag and no env fallback, unlike its two sibling scripts — so it silently hit whatever was on 8055. Now accepts `--target`, falls back to `D7_DIRECTUS_PUBLIC_URL`, and selects `https` by protocol, which it previously could not do at all.

## Misc

`.claude/settings.local.json` is now ignored by the repo. It can contain tokens and credentials and was previously covered only by a personal global ignore, so anyone else cloning had no protection. Two extensions still carried `"Please enter a description for your extension"`; both now describe what they do.

## Not included

`d7/flows.json` is stale — last exported 2026-07-17, and the live database disagrees with it (`Queue Food Pantry Translation ▸ On Update` is `inactive` there, `active` in the snapshot). Re-exporting from a local dev instance would also churn `run_counter`/`error_counter`, so that belongs in a deliberate export from whichever instance is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)