### PR TITLE
Enable CACHE_AUTO_PURGE for Directus

### DIFF
--- a/yaml/d7.yaml
+++ b/yaml/d7.yaml
@@ -76,6 +76,7 @@ services:
       KEY: ${D7_DIRECTUS_KEY}
       CACHE_ENABLED: "true"
       CACHE_STORE: "redis"
+      CACHE_AUTO_PURGE: "true"
       REDIS_HOST: d7_redis
       REDIS_PORT: 6379
       MQ_REDIS_HOST: ${MQ_REDIS_HOST}


### PR DESCRIPTION
## Problem

The d7 Directus service runs with `CACHE_ENABLED=true` and `CACHE_STORE=redis`, but `CACHE_AUTO_PURGE` was never set — so it took the Directus default of `false`. The cache is never invalidated when data changes.

Compounding it, the permission caches in `d7_redis` carry no expiry. All nine keys currently sit at `ttl=-1`:

```
permissions:raw-permissions-747ab269      ttl=-1
permissions:roles-tree-6d538614           ttl=-1
permissions:global-access-b32ccc6         ttl=-1
permissions:policies-ip-access-7457fe1a   ttl=-1
permissions:policies-3fe7364c             ttl=-1
...
```

No auto-purge plus no TTL means stale policy and permission state can persist indefinitely, which shows up as edits and deletions in the admin UI appearing not to take effect.

## Change

Adds `CACHE_AUTO_PURGE: "true"` alongside the existing cache vars, so the cache is purged on data changes. Declared as a literal, matching the surrounding `CACHE_ENABLED` / `CACHE_STORE` convention — no new env var, so `env/d7.env.template` is unchanged.

## Verification

`docker compose -p frg-d7 --env-file env/d7.env -f yaml/d7.yaml config` parses and resolves the value:

```
CACHE_AUTO_PURGE: "true"
CACHE_ENABLED: "true"
CACHE_STORE: redis
```

Takes effect on the next recreate of `d7_directus`. Note that this prevents *future* staleness; the existing no-TTL keys still need a one-time `docker exec d7_redis redis-cli flushall` (Directus cache only — `mq_redis` holds the BullMQ jobs and is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)